### PR TITLE
Feat: MyFoldersAreaLogOut 컴포넌트 구현 및 basecomponent 버그 수정

### DIFF
--- a/web/components/Avatar/Avatar.tsx
+++ b/web/components/Avatar/Avatar.tsx
@@ -15,7 +15,7 @@ const defaultProps = {
   placeholder: 'empty',
 };
 
-const Avatar = ({ size, src, name, layout, placeholder }: Props) => {
+const Avatar = ({ size, src, name, layout, placeholder, ...styles }: Props) => {
   return (
     <S.AvatarWrapper>
       <S.AvatarImg
@@ -25,6 +25,7 @@ const Avatar = ({ size, src, name, layout, placeholder }: Props) => {
         layout={layout}
         placeholder={placeholder}
         alt="프로필 사진"
+        {...styles}
       />
       {name && <S.AvatarName>{name}</S.AvatarName>}
     </S.AvatarWrapper>

--- a/web/components/Button/Button.tsx
+++ b/web/components/Button/Button.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 const defaultProps = {
   type: 'submit',
-  version: 'default',
+  version: '',
 };
 
 const Button = ({
@@ -28,7 +28,7 @@ const Button = ({
       version={version}
       onClick={onClick}
       disabled={disabled}
-      style={{ ...styles }}
+      {...styles}
     >
       {children}
     </S.Button>

--- a/web/components/Button/Button.tsx
+++ b/web/components/Button/Button.tsx
@@ -10,7 +10,6 @@ interface Props {
 }
 
 const defaultProps = {
-  type: 'submit',
   version: '',
 };
 

--- a/web/components/Input/Input.tsx
+++ b/web/components/Input/Input.tsx
@@ -25,7 +25,7 @@ const Input = ({
         placeholder={placeholder}
         maxLength={maxLength}
         onChange={onChange}
-        style={{ ...styles }}
+        {...styles}
       />
       <S.Action>{children}</S.Action>
     </S.Wrapper>

--- a/web/components/Text/Text.tsx
+++ b/web/components/Text/Text.tsx
@@ -30,7 +30,7 @@ const Text = ({
         weight={weight}
         version={version}
         fontFamily={fontFamily}
-        style={{ ...styles }}
+        {...styles}
       >
         {children}
       </S.Text>

--- a/web/pages/components/MyFoldersAreaLogOut/MyFoldersAreaLogOut.style.ts
+++ b/web/pages/components/MyFoldersAreaLogOut/MyFoldersAreaLogOut.style.ts
@@ -41,6 +41,8 @@ export const MainColor = styled(Text)`
 `;
 
 export const Description = styled(Text)`
+  font-size: ${({ theme }) => theme.fontSize.h[2]};
+  font-weight: 500;
   text-align: center;
 `;
 

--- a/web/pages/components/MyFoldersAreaLogOut/MyFoldersAreaLogOut.style.ts
+++ b/web/pages/components/MyFoldersAreaLogOut/MyFoldersAreaLogOut.style.ts
@@ -1,0 +1,58 @@
+import styled from '@emotion/styled';
+import Image from 'next/image';
+import { Button, Text } from '../../../components';
+
+export const AreaContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 1200px;
+  height: 932px;
+`;
+
+export const BackgroundImage = styled(Image)`
+  position: relative;
+`;
+
+export const ContentContainer = styled.div`
+  position: absolute;
+`;
+
+export const TextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 24px;
+`;
+
+export const Header = styled(Text)`
+  font-size: ${({ theme }) => theme.fontSize.l[1]};
+  font-weight: 700;
+  text-align: center;
+  line-height: 52px;
+`;
+
+export const MainColor = styled(Text)`
+  font-size: ${({ theme }) => theme.fontSize.l[1]};
+  font-weight: 700;
+  color: ${({ theme }) => theme.colors.main[0]};
+`;
+
+export const Description = styled(Text)`
+  text-align: center;
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-top: 50px;
+  gap: 8px;
+`;
+
+export const SignUpButton = styled(Button)`
+  background-color: ${({ theme }) => theme.colors.mainLight[0]};
+`;

--- a/web/pages/components/MyFoldersAreaLogOut/MyFoldersAreaLogOut.style.ts
+++ b/web/pages/components/MyFoldersAreaLogOut/MyFoldersAreaLogOut.style.ts
@@ -7,8 +7,8 @@ export const AreaContainer = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  width: 1200px;
-  height: 932px;
+  width: 100%;
+  height: auto;
 `;
 
 export const BackgroundImage = styled(Image)`

--- a/web/pages/components/MyFoldersAreaLogOut/MyFoldersAreaLogOut.tsx
+++ b/web/pages/components/MyFoldersAreaLogOut/MyFoldersAreaLogOut.tsx
@@ -13,12 +13,13 @@ const MyFoldersAreaLogOut = () => {
       <S.ContentContainer>
         <S.TextWrapper>
           <S.Header>
-            지금 바로 <br></br>
-            <S.MainColor>나만의 북마크 폴더</S.MainColor>를<br></br>
+            지금 바로 <br />
+            <S.MainColor>나만의 북마크 폴더</S.MainColor>를<br />
             만들어 보세요!
           </S.Header>
           <S.Description>
-            북마크 폴더를 공유하고 싶을 땐 전체 공개<br></br>
+            북마크 폴더를 공유하고 싶을 땐 전체 공개
+            <br />
             나만 보고 싶을 땐 나만 보기 설정이 가능해요 😎
           </S.Description>
         </S.TextWrapper>

--- a/web/pages/components/MyFoldersAreaLogOut/MyFoldersAreaLogOut.tsx
+++ b/web/pages/components/MyFoldersAreaLogOut/MyFoldersAreaLogOut.tsx
@@ -1,4 +1,4 @@
-import { Button, Text } from '../../../components';
+import { Button } from '../../../components';
 import * as S from './MyFoldersAreaLogOut.style';
 
 const MyFoldersAreaLogOut = () => {
@@ -19,7 +19,7 @@ const MyFoldersAreaLogOut = () => {
           </S.Header>
           <S.Description>
             북마크 폴더를 공유하고 싶을 땐 전체 공개<br></br>
-            나만 보고 싶을 땐 나만 보기 설정이 가능해요 😎{' '}
+            나만 보고 싶을 땐 나만 보기 설정이 가능해요 😎
           </S.Description>
         </S.TextWrapper>
         <S.ButtonWrapper>

--- a/web/pages/components/MyFoldersAreaLogOut/MyFoldersAreaLogOut.tsx
+++ b/web/pages/components/MyFoldersAreaLogOut/MyFoldersAreaLogOut.tsx
@@ -1,0 +1,34 @@
+import { Button, Text } from '../../../components';
+import * as S from './MyFoldersAreaLogOut.style';
+
+const MyFoldersAreaLogOut = () => {
+  return (
+    <S.AreaContainer>
+      <S.BackgroundImage
+        src="/backgrounds/myFoldersArea.svg"
+        layout="fixed"
+        width={600}
+        height={550}
+      />
+      <S.ContentContainer>
+        <S.TextWrapper>
+          <S.Header>
+            지금 바로 <br></br>
+            <S.MainColor>나만의 북마크 폴더</S.MainColor>를<br></br>
+            만들어 보세요!
+          </S.Header>
+          <S.Description>
+            북마크 폴더를 공유하고 싶을 땐 전체 공개<br></br>
+            나만 보고 싶을 땐 나만 보기 설정이 가능해요 😎{' '}
+          </S.Description>
+        </S.TextWrapper>
+        <S.ButtonWrapper>
+          <Button type="submit">로그인</Button>
+          <S.SignUpButton type="submit">회원가입</S.SignUpButton>
+        </S.ButtonWrapper>
+      </S.ContentContainer>
+    </S.AreaContainer>
+  );
+};
+
+export default MyFoldersAreaLogOut;

--- a/web/pages/components/MyFoldersAreaLogOut/index.ts
+++ b/web/pages/components/MyFoldersAreaLogOut/index.ts
@@ -1,0 +1,3 @@
+import MyFoldersAreaLogOut from './MyFoldersAreaLogOut';
+
+export default MyFoldersAreaLogOut;

--- a/web/pages/components/index.ts
+++ b/web/pages/components/index.ts
@@ -1,0 +1,1 @@
+export { default as MyFoldersAreaLogOut } from './MyFoldersAreaLogOut';

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -1,8 +1,13 @@
 import type { NextPage } from 'next';
 import * as S from './index.style';
+import { MyFoldersAreaLogOut } from './components';
 
 const MainPage: NextPage = () => {
-  return <S.Div>메인페이지입니당</S.Div>;
+  return (
+    <S.Div>
+      <MyFoldersAreaLogOut />
+    </S.Div>
+  );
 };
 
 export default MainPage;

--- a/web/public/backgrounds/myFoldersArea.svg
+++ b/web/public/backgrounds/myFoldersArea.svg
@@ -1,0 +1,11 @@
+<svg width="599" height="548" viewBox="0 0 599 548" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="317.5" cy="268.5" r="202.5" fill="#A0C4FF" fill-opacity="0.05"/>
+<circle cx="357.5" cy="330.5" r="202.5" fill="#A0C4FF" fill-opacity="0.05"/>
+<circle cx="467" cy="462" r="86" fill="#A0C4FF" fill-opacity="0.05"/>
+<circle cx="453" cy="376" r="61" fill="#A0C4FF" fill-opacity="0.05"/>
+<circle cx="216" cy="392" r="150" fill="#A0C4FF" fill-opacity="0.05"/>
+<circle cx="449" cy="150" r="150" fill="#A0C4FF" fill-opacity="0.05"/>
+<circle cx="246" cy="117" r="75" fill="#A0C4FF" fill-opacity="0.05"/>
+<circle cx="48.5" cy="206.5" r="48.5" fill="#A0C4FF" fill-opacity="0.05"/>
+<circle cx="37" cy="300" r="29" fill="#A0C4FF" fill-opacity="0.05"/>
+</svg>


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->
pages/components/MyFoldersAreaLogOut 이라는 이름으로 폴더를 생성했습니다. (메인페이지에만 사용해서)
<img width="497" alt="스크린샷 2022-07-28 오후 4 34 50" src="https://user-images.githubusercontent.com/76620786/181449015-9b512d8c-5b12-46c7-a987-1dc8524e6478.png">


### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->
피그마 디자인과 동일하게 만들었습니다.

- public/backgrounds/myFoldersArea.svg 추가

- 추가 수정 사항
style.ts 파일에서 styled(Text), styled(Button) 했을 때 style이 수정이 안되는 부분 수정
button, avatar, input, text 파일에서 아래와 같이 수정했습니다.
```
<S.Text
        size={size}
        color={color}
        weight={weight}
        version={version}
        fontFamily={fontFamily}
        {...styles} // style={{...styles}}에서 {...styles}로 수정
      >
        {children}
</S.Text>
```

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->
- 변수명이 괜찮나요?

### 🚀 연관된 이슈
closes #18 