### PR TITLE
Feat: UseInfo 컴포넌트 구현 + Text font-family 수정

### DIFF
--- a/web/components/Text/Text.style.ts
+++ b/web/components/Text/Text.style.ts
@@ -17,7 +17,7 @@ const Header = ({ theme }: ThemeProps) => css`
 
 const Logo = ({ theme }: ThemeProps) => css`
   font-size: 50px;
-  font-family: "Dongle", sans-serif;
+  font-family: 'Dongle', sans-serif;
   font-weight: bold;
   color: ${theme.colors.main[0]};
 `;
@@ -26,7 +26,7 @@ export const Text = styled.span`
   font-size: ${({ size }: Props) => size};
   font-weight: ${({ weight }: Props) => weight};
   color: ${({ color }: Props) => color};
-  font-family: ${({ fontFamily }: Props) => fontFamily};
+  font-family: 'Noto Sans KR', sans-serif;
 
   ${({ version }: Props) => {
     switch (version) {

--- a/web/components/Text/Text.tsx
+++ b/web/components/Text/Text.tsx
@@ -6,7 +6,6 @@ interface Props {
   color?: string;
   weight?: string | number;
   version?: string;
-  fontFamily?: string;
 }
 
 const defaultProps = {

--- a/web/components/Text/Text.tsx
+++ b/web/components/Text/Text.tsx
@@ -13,15 +13,7 @@ const defaultProps = {
   size: '14px',
 };
 
-const Text = ({
-  children,
-  size,
-  color,
-  weight,
-  version,
-  fontFamily,
-  ...styles
-}: Props) => {
+const Text = ({ children, size, color, weight, version, ...styles }: Props) => {
   return (
     <>
       <S.Text
@@ -29,7 +21,6 @@ const Text = ({
         color={color}
         weight={weight}
         version={version}
-        fontFamily={fontFamily}
         {...styles}
       >
         {children}

--- a/web/pages/_document.tsx
+++ b/web/pages/_document.tsx
@@ -17,9 +17,9 @@ class MyDocument extends Document {
       <Html>
         <Head>
           <link
-            href="https://fonts.googleapis.com/css2?family=Black+Han+Sans&display=swap"
+            href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100;300;400;500;700;900&display=swap"
             rel="stylesheet"
-          />
+          ></link>
           <link
             href="https://fonts.googleapis.com/css2?family=Dongle:wght@300;400;700&display=swap"
             rel="stylesheet"

--- a/web/pages/components/UseInfo/UseInfo.style.ts
+++ b/web/pages/components/UseInfo/UseInfo.style.ts
@@ -1,0 +1,71 @@
+import styled from '@emotion/styled';
+import { Button, Text } from '../../../components';
+
+export const UseInfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  height: auto;
+  padding: 156px 0;
+  background-color: ${({ theme }) => theme.colors.mainLight[1]};
+`;
+
+export const TextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  gap: 28px;
+`;
+
+export const Header = styled(Text)`
+  font-size: ${({ theme }) => theme.fontSize.l[1]};
+  font-weight: 700;
+  text-align: center;
+  line-height: 52px;
+`;
+
+export const MainColorHeader = styled(Header)`
+  color: ${({ theme }) => theme.colors.main[0]};
+`;
+
+export const Description = styled(Text)`
+  font-size: ${({ theme }) => theme.fontSize.h[1]};
+  font-weight: 700;
+  text-align: center;
+  line-height: 30px;
+`;
+
+export const MainColorDes = styled(Description)`
+  color: ${({ theme }) => theme.colors.main[0]};
+`;
+
+export const LogoText = styled(Text)`
+  margin-right: 2px;
+  font-weight: 700;
+  font-size: ${({ theme }) => theme.fontSize.t[0]};
+  color: ${({ theme }) => theme.colors.white[0]};
+`;
+
+export const ButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  margin-top: 58px;
+  gap: 8px;
+`;
+
+export const LinkButton = styled(Button)`
+  width: 100%;
+  height: 70px;
+  padding: 26.5px 32px;
+  font-weight: 700;
+  font-size: ${({ theme }) => theme.fontSize.h[0]};
+  color: ${({ theme }) => theme.colors.white[0]};
+`;

--- a/web/pages/components/UseInfo/UseInfo.tsx
+++ b/web/pages/components/UseInfo/UseInfo.tsx
@@ -1,0 +1,29 @@
+import * as S from './UseInfo.style';
+
+const UseInfo = () => {
+  return (
+    <S.UseInfoContainer>
+      <S.TextWrapper>
+        <S.Header>
+          <S.MainColorHeader>나만의 북마크</S.MainColorHeader>를<br />
+          편하게 공유하세요!
+        </S.Header>
+        <S.Description>
+          내 바탕화면을 깔끔하게
+          <S.MainColorDes> 북마크를 폴더로 정리 싹!</S.MainColorDes>
+          <br />
+          원하는 북마크 폴더를
+          <S.MainColorDes> 내 폴더 모음으로 쏙!</S.MainColorDes>
+        </S.Description>
+      </S.TextWrapper>
+      <S.ButtonWrapper>
+        <S.LinkButton type="submit">
+          <S.LogoText version="logo">링북</S.LogoText>
+          100% 활용법 ＞
+        </S.LinkButton>
+      </S.ButtonWrapper>
+    </S.UseInfoContainer>
+  );
+};
+
+export default UseInfo;

--- a/web/pages/components/UseInfo/index.ts
+++ b/web/pages/components/UseInfo/index.ts
@@ -1,0 +1,3 @@
+import UseInfo from './UseInfo';
+
+export default UseInfo;

--- a/web/pages/components/index.ts
+++ b/web/pages/components/index.ts
@@ -1,1 +1,2 @@
 export { default as MyFoldersAreaLogOut } from './MyFoldersAreaLogOut';
+export { default as UseInfo } from './UseInfo';


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->
- pages/components/UseInfo 폴더를 만들어서 사용했습니다. (메인 페이지에만 사용)
![스크린샷 2022-07-28 오후 6 40 57](https://user-images.githubusercontent.com/76620786/181474976-d1a723fb-ea25-424e-bec5-67c2e072a5f8.png)

### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->
- 디자인만 보고 만든거라 로직이 없습니다.

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->
- 추가적으로 text font-family 수정했습니다 (Text props에서 font-family 삭제하고 Noto Sans로 고정했습니다)
<img width="403" alt="스크린샷 2022-07-29 오전 12 31 49" src="https://user-images.githubusercontent.com/76620786/181577959-b6fbb32b-0756-48c3-8a3e-4ebd9626f234.png">

### 🚀 연관된 이슈
closes #20 