### PR TITLE
Feat: NavigationBar컴포넌트 구현

### DIFF
--- a/web/components/Footer/Footer.style.ts
+++ b/web/components/Footer/Footer.style.ts
@@ -4,7 +4,7 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 450px;
+  height: 440px;
   border-top: ${({ theme }) => `1px solid ${theme.colors.gray[4]}`};
 `;
 
@@ -56,7 +56,7 @@ export const FooterCopyright = styled.div`
   display: flex;
   align-items: center;
   width: 100%;
-  height: 70px;
+  height: 60px;
   background-color: ${({ theme }) => theme.colors.main[0]};
 `;
 

--- a/web/components/Footer/Footer.style.ts
+++ b/web/components/Footer/Footer.style.ts
@@ -5,7 +5,7 @@ export const Container = styled.div`
   flex-direction: column;
   width: 100%;
   height: 440px;
-  border-top: ${({ theme }) => `1px solid ${theme.colors.gray[4]}`};
+  border-top: ${({ theme }) => `1px solid ${theme.colors.gray[5]}`};
 `;
 
 // FooterText Area

--- a/web/components/Footer/FooterItem/FooterItem.tsx
+++ b/web/components/Footer/FooterItem/FooterItem.tsx
@@ -24,10 +24,10 @@ const FooterItem = ({ title, textArr }: Props) => {
   return (
     <S.Container>
       <S.Title>{title}</S.Title>
-      {textArr.map((text) => {
+      {textArr.map((text, index) => {
         const { strong, plane } = text;
         return (
-          <S.TextContainer>
+          <S.TextContainer key={index}>
             <S.Strong>{strong}</S.Strong>
             <S.Plane>{plane}</S.Plane>
           </S.TextContainer>

--- a/web/components/NavigationBar/NavigationBar.style.ts
+++ b/web/components/NavigationBar/NavigationBar.style.ts
@@ -1,0 +1,69 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  box-sizing: border-box;
+  width: 100%;
+  height: 60px;
+  background-color: ${({ theme }) => theme.colors.white[0]};
+`;
+
+export const ItemContainer = styled.div`
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  max-width: 1200px;
+  height: 50px;
+  margin: 5px auto;
+`;
+
+export const Logo = styled.a`
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+`;
+
+export const Nav = styled.nav`
+  display: flex;
+  flex-grow: 1;
+  gap: 10px;
+  margin-left: 60px;
+`;
+
+export const Line = styled.div`
+  color: ${({ theme }) => theme.colors.gray[4]};
+`;
+
+export const NavItem = styled.a`
+  padding: 12px 10px;
+  color: ${({ theme }) => theme.colors.black[0]};
+  font-weight: 600;
+  font-size: ${({ theme }) => theme.fontSize.h[2]};
+  font-family: 'Noto Sans KR', sans-serif;
+  text-decoration: none;
+  border-radius: 10px;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.gray[5]};
+  }
+`;
+
+export const User = styled.div`
+  display: flex;
+  gap: 10px;
+`;
+
+export const UserSignUp = styled.button`
+  font-weight: 600;
+  font-size: ${({ theme }) => theme.fontSize.b[1]};
+  background-color: transparent;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.gray[5]};
+  }
+`;

--- a/web/components/NavigationBar/NavigationBar.style.ts
+++ b/web/components/NavigationBar/NavigationBar.style.ts
@@ -8,6 +8,7 @@ export const Container = styled.div`
   width: 100%;
   height: 60px;
   background-color: ${({ theme }) => theme.colors.white[0]};
+  border-bottom: ${({ theme }) => `1px solid ${theme.colors.gray[5]}`};
 `;
 
 export const ItemContainer = styled.div`
@@ -50,7 +51,7 @@ export const NavItem = styled.a`
   }
 `;
 
-export const User = styled.div`
+export const Login = styled.div`
   display: flex;
   gap: 10px;
 `;

--- a/web/components/NavigationBar/NavigationBar.style.ts
+++ b/web/components/NavigationBar/NavigationBar.style.ts
@@ -7,6 +7,7 @@ export const Container = styled.div`
   box-sizing: border-box;
   width: 100%;
   height: 60px;
+  padding: 5px 0;
   background-color: ${({ theme }) => theme.colors.white[0]};
   border-bottom: ${({ theme }) => `1px solid ${theme.colors.gray[5]}`};
 `;
@@ -17,7 +18,7 @@ export const ItemContainer = styled.div`
   align-items: center;
   max-width: 1200px;
   height: 50px;
-  margin: 5px auto;
+  margin: auto;
 `;
 
 export const Logo = styled.a`
@@ -51,12 +52,12 @@ export const NavItem = styled.a`
   }
 `;
 
-export const Login = styled.div`
+export const UserContainer = styled.div`
   display: flex;
   gap: 10px;
 `;
 
-export const UserSignUp = styled.button`
+export const UserButton = styled.button`
   font-weight: 600;
   font-size: ${({ theme }) => theme.fontSize.b[1]};
   background-color: transparent;

--- a/web/components/NavigationBar/NavigationBar.tsx
+++ b/web/components/NavigationBar/NavigationBar.tsx
@@ -1,10 +1,26 @@
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import Avatar from '../Avatar';
 import Button from '../Button';
 import Icon from '../Icon';
 import Text from '../Text';
 import * as S from './NavigationBar.style';
 
-const NavigationBar = () => {
+interface Props {
+  isLogin: boolean;
+}
+
+const defaultProps = {
+  isLogin: false,
+};
+
+const NavigationBar = ({ isLogin }: Props) => {
+  const [isLoggedIn, setisLoggedIn] = useState(isLogin);
+
+  useEffect(() => {
+    setisLoggedIn(isLogin);
+  }, [isLogin]);
+
   return (
     <S.Container>
       <S.ItemContainer>
@@ -22,16 +38,35 @@ const NavigationBar = () => {
             <S.NavItem>이용방법</S.NavItem>
           </Link>
         </S.Nav>
-        <S.Line>|</S.Line>
-        <S.User>
-          <S.UserSignUp>회원가입</S.UserSignUp>
-          <Button type="button" version="navBar">
-            로그인
-          </Button>
-        </S.User>
+        {isLoggedIn ? (
+          <>
+            <Avatar size={35} />
+            <S.Line>|</S.Line>
+            <S.UserContainer>
+              <Link href="/mypage" passHref>
+                <S.NavItem>마이페이지</S.NavItem>
+              </Link>
+              <Button type="button" version="navBar">
+                새 폴더 작성
+              </Button>
+            </S.UserContainer>
+          </>
+        ) : (
+          <>
+            <S.Line>|</S.Line>
+            <S.UserContainer>
+              <S.UserButton>회원가입</S.UserButton>
+              <Button type="button" version="navBar">
+                로그인
+              </Button>
+            </S.UserContainer>
+          </>
+        )}
       </S.ItemContainer>
     </S.Container>
   );
 };
+
+NavigationBar.defaultProps = defaultProps;
 
 export default NavigationBar;

--- a/web/components/NavigationBar/NavigationBar.tsx
+++ b/web/components/NavigationBar/NavigationBar.tsx
@@ -15,10 +15,10 @@ const defaultProps = {
 };
 
 const NavigationBar = ({ isLogin }: Props) => {
-  const [isLoggedIn, setisLoggedIn] = useState(isLogin);
+  const [isLoggedIn, setIsLoggedIn] = useState(isLogin);
 
   useEffect(() => {
-    setisLoggedIn(isLogin);
+    setIsLoggedIn(isLogin);
   }, [isLogin]);
 
   return (
@@ -43,7 +43,7 @@ const NavigationBar = ({ isLogin }: Props) => {
             <Avatar size={35} />
             <S.Line>|</S.Line>
             <S.UserContainer>
-              <Link href="/mypage" passHref>
+              <Link href="/myPage" passHref>
                 <S.NavItem>마이페이지</S.NavItem>
               </Link>
               <Button type="button" version="navBar">

--- a/web/components/NavigationBar/NavigationBar.tsx
+++ b/web/components/NavigationBar/NavigationBar.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link';
+import Button from '../Button';
+import Icon from '../Icon';
+import Text from '../Text';
+import * as S from './NavigationBar.style';
+
+const NavigationBar = () => {
+  return (
+    <S.Container>
+      <S.ItemContainer>
+        <Link href="/" passHref>
+          <S.Logo href="/">
+            <Text version="logo">링북</Text>
+            <Icon name="bookmark" size={35} />
+          </S.Logo>
+        </Link>
+        <S.Nav>
+          <Link href="/folderList" passHref>
+            <S.NavItem>북마크리스트</S.NavItem>
+          </Link>
+          <Link href="/information" passHref>
+            <S.NavItem>이용방법</S.NavItem>
+          </Link>
+        </S.Nav>
+        <S.Line>|</S.Line>
+        <S.User>
+          <S.UserSignUp>회원가입</S.UserSignUp>
+          <Button type="button" version="navBar">
+            로그인
+          </Button>
+        </S.User>
+      </S.ItemContainer>
+    </S.Container>
+  );
+};
+
+export default NavigationBar;

--- a/web/components/NavigationBar/NavigationBar.tsx
+++ b/web/components/NavigationBar/NavigationBar.tsx
@@ -1,9 +1,6 @@
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
-import Avatar from '../Avatar';
-import Button from '../Button';
-import Icon from '../Icon';
-import Text from '../Text';
+import { Avatar, Button, Icon, Text } from '../index';
 import * as S from './NavigationBar.style';
 
 interface Props {

--- a/web/components/NavigationBar/index.ts
+++ b/web/components/NavigationBar/index.ts
@@ -1,0 +1,3 @@
+import NavigationBar from './NavigationBar';
+
+export default NavigationBar;

--- a/web/components/index.ts
+++ b/web/components/index.ts
@@ -6,3 +6,4 @@ export { default as Input } from './Input';
 export { default as Text } from './Text';
 export { default as Tab } from './Tab';
 export { default as Tag } from './Tag';
+export { default as NavigationBar } from './NavigationBar';

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -1,6 +1,6 @@
 import { ThemeProvider } from '@emotion/react';
 import type { AppProps } from 'next/app';
-import { Footer } from '../components';
+import { Footer, NavigationBar } from '../components';
 import GlobalStyle from '../styles/GlobalStyle';
 import theme from '../styles/themes';
 
@@ -8,6 +8,7 @@ function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider theme={theme}>
       <GlobalStyle />
+      <NavigationBar />
       <Component {...pageProps} />
       <Footer />
     </ThemeProvider>


### PR DESCRIPTION
# Navigation Bar Component 구현

## 📌 설명
NavigationBar Component를 구현했습니다.

- 미로그인 상태
![image](https://user-images.githubusercontent.com/72294509/181523721-e9f3b271-f650-4b03-9fa6-d374c4b240f1.png)

- 로그인 후
![image](https://user-images.githubusercontent.com/72294509/181523874-fecdd177-d342-43c9-87db-4a4c6194883c.png)

<br />

## 🎨 구현 내용
- Navigation Bar 구현

<br />

## ✅ 중점적으로 봐줬으면 하는 부분
### 1. 상태
임의의 prop(`isLogin`)과 상태 (`isLoggedIn`) 를 가집니다.

이 부분은 추후에 `useRecoilState`를 사용하는 방식으로 리팩토링 할 예정입니다. 

### 2. 링크
임의로 링크를 연결해놨습니다. 

- 북마크리스트 -> `/folderList`
- 이용방법 -> `/information`
- 마이페이지 -> `/myPage`
- **로그인, 회원가입**은 모달로 띄울 예정이기 때문에 링크를 추가하지 않았습니다. 
- **새 폴더 만들기** 버튼의 url은 같이 의논해서 정해야 할 것 같아 추가하지 않았습니다.

### 3. 디자인
각 버튼(링크)에는 `hover`효과가 적용되어 있습니다.
![image](https://user-images.githubusercontent.com/72294509/181524499-2c13122c-0832-44ac-820b-3cb931df9d75.png)

<br />

### 🚀 연관된 이슈
Closes #12 