### PR TITLE
Feat: MyFolderAreaLogIn 컴포넌트 구현

### DIFF
--- a/web/components/Card/Card.style.ts
+++ b/web/components/Card/Card.style.ts
@@ -16,6 +16,7 @@ export const Card = styled.div<Props>`
   height: auto;
   border-radius: 10px;
   box-shadow: rgba(50, 50, 93, 0.25) 0px 6px 12px -2px, rgba(0, 0, 0, 0.3) 0px 3px 7px -3px;
+  background-color: ${({ theme }) => theme.colors.white[0]};
 
   transition-duration: 1s;
   transform: ${({reverseCard}) => reverseCard ? 'rotateY(180deg)' : 'rotateY(0)'};

--- a/web/components/Card/Card.tsx
+++ b/web/components/Card/Card.tsx
@@ -6,35 +6,10 @@ import theme from '../../styles/themes';
 import { Avatar, Icon, Text, Tag } from '../index';
 import CardBack from './CardBack/CardBack';
 import * as S from './Card.style';
-
-interface Tags {
-  id: string;
-  text: string;
-}
-interface User {
-  image: string;
-  name: string;
-}
-interface BookMarks {
-  id: number;
-  image: string;
-  title: string;
-  url: string;
-}
-
-interface Data {
-  id: number;
-  image: string;
-  title: string;
-  tags: Tags[];
-  user: User;
-  createdAt: string;
-  likes: number;
-  bookmarks: BookMarks[];
-}
+import { Folder } from '../../shared/DummyDataType';
 
 interface Props {
-  data: Data;
+  data: Folder;
   version?: string;
 }
 
@@ -44,6 +19,9 @@ const defaultProps = {
 };
 
 const Card = ({ data, version, ...styles }: Props) => {
+  const author = 'Miral'; // 나중에 수정
+  const authorImage =
+    'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80'; // 나중에 수정
   const router = useRouter();
   const [reverseCard, setReverseCard] = useState(false);
 
@@ -76,10 +54,10 @@ const Card = ({ data, version, ...styles }: Props) => {
               <S.Title>{data.title}</S.Title>
             </S.TitleWrapper>
             <S.TagWrapper>
-              <Tag tagItems={data.tags} />
+              <Tag tagItems={data.tags!} />
             </S.TagWrapper>
             <S.Info version={version}>
-              <Avatar name={data.user.name} src={data.user.image} />
+              <Avatar name={author} src={authorImage} />
               <div>
                 <Text size={theme.fontSize.c[1]}>{data.createdAt}</Text>
                 {version === 'othersCard' && (

--- a/web/components/Card/CardBack/CardBack.style.ts
+++ b/web/components/Card/CardBack/CardBack.style.ts
@@ -26,11 +26,12 @@ export const IconWrapper = styled.div`
   cursor: pointer;
 `
 
-export const BookmarkList = styled.ul`
+export const BookmarkList = styled.ul<Props>`
   height: 340px;
   padding-top: 8px;
-  overflow: auto;
-  overscroll-behavior-y: contain;
+  /* overflow: auto; */
+  overflow: ${({reverseCard}) => reverseCard ? 'auto' : 'hidden'};
+  overscroll-behavior-y: ${({reverseCard}) => reverseCard ? 'contain' : 'auto'};
   /* 스크롤바 전체 */
   &::-webkit-scrollbar {
     width: 8px;

--- a/web/components/Card/CardBack/CardBack.tsx
+++ b/web/components/Card/CardBack/CardBack.tsx
@@ -2,16 +2,10 @@ import Link from 'next/link';
 import { MouseEventHandler } from 'react';
 import { Avatar, Icon, Text } from '../../index';
 import * as S from './CardBack.style';
-
-interface Data {
-  id: number;
-  image: string;
-  title: string;
-  url: string;
-}
+import { Bookmark } from '../../../shared/DummyDataType';
 
 interface Props {
-  data: Data[];
+  data: Bookmark[];
   handleRotateCard: MouseEventHandler;
   reverseCard: boolean;
 }
@@ -26,6 +20,8 @@ const CardBack = ({
   reverseCard,
   ...styles
 }: Props) => {
+  const image =
+    'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80';
   return (
     <S.Card reverseCard={reverseCard} {...styles}>
       <S.IconWrapper onClick={handleRotateCard}>
@@ -35,7 +31,8 @@ const CardBack = ({
         {data.map((bookmark) => (
           <Link href={bookmark.url} passHref key={bookmark.id}>
             <S.Bookmark>
-              <Avatar src={bookmark.image} size={31} />
+              {/* 북마크 리스트 아이템 머지되면 수정 */}
+              <Avatar src={image} size={31} />
               <S.TextWrapper>
                 <Text weight={600}>{bookmark.title}</Text>
               </S.TextWrapper>

--- a/web/components/Card/CardBack/CardBack.tsx
+++ b/web/components/Card/CardBack/CardBack.tsx
@@ -31,7 +31,7 @@ const CardBack = ({
       <S.IconWrapper onClick={handleRotateCard}>
         <Icon name="back" size={20} />
       </S.IconWrapper>
-      <S.BookmarkList>
+      <S.BookmarkList reverseCard={reverseCard}>
         {data.map((bookmark) => (
           <Link href={bookmark.url} passHref key={bookmark.id}>
             <S.Bookmark>

--- a/web/components/Tag/Tag.tsx
+++ b/web/components/Tag/Tag.tsx
@@ -1,20 +1,15 @@
 import TagItem from './TagItem';
 import * as S from './Tag.style';
 
-interface Items {
-  id: string;
-  text: string;
-}
-
 interface Props {
-  tagItems: Items[];
+  tagItems: string[];
 }
 
 const Tag = ({ tagItems }: Props) => {
   return (
     <S.TagWrapper>
-      {tagItems.map((item) => (
-        <TagItem key={item.id}>{item.text}</TagItem>
+      {tagItems.map((item, index) => (
+        <TagItem key={index}>{item}</TagItem>
       ))}
     </S.TagWrapper>
   );

--- a/web/pages/components/FolderSlider/FolderSlider.style.ts
+++ b/web/pages/components/FolderSlider/FolderSlider.style.ts
@@ -1,0 +1,55 @@
+import styled from '@emotion/styled';
+
+interface Prop {
+  position?: string;
+  active?: boolean;
+  useCarousel?: boolean;
+};
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: auto;
+  padding-top: 60px;
+  padding-bottom: 30px;
+`;
+
+export const SliderContainer = styled.div`
+  position: relative;
+  display: flex;
+  justify-content: center;
+  width: 1260px;
+  height: 415px;
+  overflow: hidden;
+
+  @media (max-width: 1280px) {
+    width: 660px;
+  }
+  @media (max-width: 660px) {
+    width: 300px;
+  }
+`;
+
+export const CardList = styled.ul<Prop>`
+  display: flex;
+  justify-content: ${({useCarousel}) => useCarousel ? 'flex-start' : 'center'};;
+  gap: 15px;
+  width: 100%;
+  transform: ${({useCarousel}) => useCarousel ? 'translateX(-150px)' : 'none'};
+`;
+
+export const CardWrapper = styled.div<Prop>`
+  opacity: ${({active}) => active ? '1' : '0.4'};
+  // active에 따라 클릭 이벤트 설정
+  pointer-events: ${({active}) => active ? 'auto' : 'none'};
+`;
+
+export const IconWrapper = styled.div<Prop>`
+  position: absolute;
+  left: ${({position}) => position === 'left' && '8%'};
+  right: ${({position}) => position === 'right' && '8%'};
+  cursor: pointer;
+`;

--- a/web/pages/components/FolderSlider/FolderSlider.style.ts
+++ b/web/pages/components/FolderSlider/FolderSlider.style.ts
@@ -49,7 +49,13 @@ export const CardWrapper = styled.div<Prop>`
 
 export const IconWrapper = styled.div<Prop>`
   position: absolute;
-  left: ${({position}) => position === 'left' && '8%'};
-  right: ${({position}) => position === 'right' && '8%'};
+  top: 43%;
+  left: ${({position}) => position === 'left' && '3%'};
+  right: ${({position}) => position === 'right' && '3%'};
   cursor: pointer;
+
+  @media (max-width: 660px) {
+    left: ${({position}) => position === 'left' && '3%'};
+    right: ${({position}) => position === 'right' && '3%'};
+  }
 `;

--- a/web/pages/components/FolderSlider/FolderSlider.tsx
+++ b/web/pages/components/FolderSlider/FolderSlider.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef, useState } from 'react';
+import { Card, Icon } from '../../../components';
+import * as S from './FolderSlider.style';
+
+interface Tags {
+  id: string;
+  text: string;
+}
+interface User {
+  image: string;
+  name: string;
+}
+interface BookMarks {
+  id: number;
+  image: string;
+  title: string;
+  url: string;
+}
+
+interface Data {
+  id: number;
+  image: string;
+  title: string;
+  tags: Tags[];
+  user: User;
+  createdAt: string;
+  likes: number;
+  bookmarks: BookMarks[];
+}
+
+interface Props {
+  data: Data[];
+}
+
+const defaultProps = {
+  data: {},
+};
+
+const FolderSlider = ({ data }: Props) => {
+  const sliderRef = useRef<HTMLUListElement>(null);
+  const bookmarkCount = data.length;
+  const bookmarks =
+    bookmarkCount > 3 ? [data[bookmarkCount - 1], ...data, data[0]] : data;
+
+  const [winX, setWinX] = useState(1440);
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const handleClickPrevButton = () => {
+    const lastIndex = winX > 1280 ? bookmarkCount - 3 : bookmarkCount - 1;
+    if (currentIndex === 0) {
+      setCurrentIndex(lastIndex);
+    } else {
+      setCurrentIndex(currentIndex - 1);
+    }
+  };
+
+  const handleClickNextButton = () => {
+    const lastIndex = winX > 1280 ? bookmarkCount - 3 : bookmarkCount - 1;
+    if (currentIndex === lastIndex) {
+      setCurrentIndex(0);
+    } else {
+      setCurrentIndex(currentIndex + 1);
+    }
+  };
+
+  const resizeWindow = () => {
+    setWinX(window.innerWidth);
+  };
+
+  const isActive = (idx: number) => {
+    if (winX <= 1280) {
+      return currentIndex + 2 === idx + 1;
+    }
+    for (let i = 1; i <= 3; i++) {
+      if ((currentIndex + i) % (bookmarkCount + 1) === idx) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  useEffect(() => {
+    setWinX(window.innerWidth);
+  }, []);
+
+  useEffect(() => {
+    if (sliderRef.current) {
+      sliderRef.current.style.transition = `all 0.5s `;
+      if (winX > 660) {
+        sliderRef.current.style.transform = `translateX(calc(-150px + (-315px * ${currentIndex}))`;
+      } else {
+        sliderRef.current.style.transform = `translateX(calc(-315px + (-315px * ${currentIndex}))`;
+      }
+    }
+  }, [currentIndex, winX]);
+
+  useEffect(() => {
+    window.addEventListener('resize', resizeWindow);
+    return () => {
+      window.removeEventListener('resize', resizeWindow);
+    };
+  }, []);
+
+  return (
+    <S.Container>
+      {bookmarks.length > 3 ? (
+        <>
+          <S.SliderContainer>
+            <S.CardList useCarousel={true} ref={sliderRef}>
+              {bookmarks.map((cardInfo, idx) => (
+                <S.CardWrapper
+                  key={cardInfo.id * idx + 1}
+                  active={isActive(idx)}
+                >
+                  <Card data={cardInfo} />
+                </S.CardWrapper>
+              ))}
+            </S.CardList>
+          </S.SliderContainer>
+          <S.IconWrapper position="left" onClick={handleClickPrevButton}>
+            <Icon name="arrowLeft" size={40} />
+          </S.IconWrapper>
+          <S.IconWrapper position="right" onClick={handleClickNextButton}>
+            <Icon name="arrowRight" size={40} />
+          </S.IconWrapper>
+        </>
+      ) : (
+        <S.CardList useCarousel={false}>
+          {bookmarks.map((cardInfo, idx) => (
+            <Card key={idx} data={cardInfo} />
+          ))}
+        </S.CardList>
+      )}
+    </S.Container>
+  );
+};
+
+FolderSlider.defaultProps = defaultProps;
+
+export default FolderSlider;

--- a/web/pages/components/FolderSlider/FolderSlider.tsx
+++ b/web/pages/components/FolderSlider/FolderSlider.tsx
@@ -1,35 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
 import { Card, Icon } from '../../../components';
 import * as S from './FolderSlider.style';
-
-interface Tags {
-  id: string;
-  text: string;
-}
-interface User {
-  image: string;
-  name: string;
-}
-interface BookMarks {
-  id: number;
-  image: string;
-  title: string;
-  url: string;
-}
-
-interface Data {
-  id: number;
-  image: string;
-  title: string;
-  tags: Tags[];
-  user: User;
-  createdAt: string;
-  likes: number;
-  bookmarks: BookMarks[];
-}
+import { Folder } from '../../../shared/DummyDataType';
 
 interface Props {
-  data: Data[];
+  data: Folder[];
 }
 
 const defaultProps = {
@@ -107,12 +82,12 @@ const FolderSlider = ({ data }: Props) => {
         <>
           <S.SliderContainer>
             <S.CardList useCarousel={true} ref={sliderRef}>
-              {bookmarks.map((cardInfo, idx) => (
+              {bookmarks.map((bookmark, idx) => (
                 <S.CardWrapper
-                  key={cardInfo.id * idx + 1}
+                  key={bookmark.id * idx + 1}
                   active={isActive(idx)}
                 >
-                  <Card data={cardInfo} />
+                  <Card data={bookmark} />
                 </S.CardWrapper>
               ))}
             </S.CardList>
@@ -126,8 +101,8 @@ const FolderSlider = ({ data }: Props) => {
         </>
       ) : (
         <S.CardList useCarousel={false}>
-          {bookmarks.map((cardInfo, idx) => (
-            <Card key={idx} data={cardInfo} />
+          {bookmarks.map((bookmark, idx) => (
+            <Card key={idx} data={bookmark} />
           ))}
         </S.CardList>
       )}

--- a/web/pages/components/FolderSlider/FolderSlider.tsx
+++ b/web/pages/components/FolderSlider/FolderSlider.tsx
@@ -22,7 +22,7 @@ const FolderSlider = ({ data }: Props) => {
 
   const handleClickPrevButton = () => {
     const lastIndex = winX > 1280 ? bookmarkCount - 3 : bookmarkCount - 1;
-    if (currentIndex === 0) {
+    if (currentIndex <= 0) {
       setCurrentIndex(lastIndex);
     } else {
       setCurrentIndex(currentIndex - 1);
@@ -31,7 +31,7 @@ const FolderSlider = ({ data }: Props) => {
 
   const handleClickNextButton = () => {
     const lastIndex = winX > 1280 ? bookmarkCount - 3 : bookmarkCount - 1;
-    if (currentIndex === lastIndex) {
+    if (currentIndex >= lastIndex) {
       setCurrentIndex(0);
     } else {
       setCurrentIndex(currentIndex + 1);
@@ -62,7 +62,12 @@ const FolderSlider = ({ data }: Props) => {
     if (sliderRef.current) {
       sliderRef.current.style.transition = `all 0.5s `;
       if (winX > 660) {
-        sliderRef.current.style.transform = `translateX(calc(-150px + (-315px * ${currentIndex}))`;
+        if (currentIndex >= bookmarkCount - 3) {
+          setCurrentIndex(0);
+          sliderRef.current.style.transform = `translateX(-150px)`;
+        } else {
+          sliderRef.current.style.transform = `translateX(calc(-150px + (-315px * ${currentIndex}))`;
+        }
       } else {
         sliderRef.current.style.transform = `translateX(calc(-315px + (-315px * ${currentIndex}))`;
       }
@@ -91,13 +96,13 @@ const FolderSlider = ({ data }: Props) => {
                 </S.CardWrapper>
               ))}
             </S.CardList>
+            <S.IconWrapper position="left" onClick={handleClickPrevButton}>
+              <Icon name="arrowLeft" size={40} />
+            </S.IconWrapper>
+            <S.IconWrapper position="right" onClick={handleClickNextButton}>
+              <Icon name="arrowRight" size={40} />
+            </S.IconWrapper>
           </S.SliderContainer>
-          <S.IconWrapper position="left" onClick={handleClickPrevButton}>
-            <Icon name="arrowLeft" size={40} />
-          </S.IconWrapper>
-          <S.IconWrapper position="right" onClick={handleClickNextButton}>
-            <Icon name="arrowRight" size={40} />
-          </S.IconWrapper>
         </>
       ) : (
         <S.CardList useCarousel={false}>

--- a/web/pages/components/FolderSlider/index.ts
+++ b/web/pages/components/FolderSlider/index.ts
@@ -1,0 +1,3 @@
+import FolderSlider from './FolderSlider';
+
+export default FolderSlider;

--- a/web/pages/components/MyFoldersAreaLogIn/MyFoldersAreaLogIn.style.ts
+++ b/web/pages/components/MyFoldersAreaLogIn/MyFoldersAreaLogIn.style.ts
@@ -1,0 +1,28 @@
+import styled from '@emotion/styled';
+import { Button } from "../../../components";
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: auto;
+  padding-top: 100px;
+  padding-bottom: 170px;
+`;
+
+export const Header = styled.div`
+  font-size: ${({ theme }) => theme.fontSize.l[1]};
+  font-weight: 700;
+  text-align: center;
+  line-height: 52px;
+
+  &>span {
+    font-size: inherit;
+  }
+`
+
+export const StyledButton = styled(Button)`
+  box-shadow: rgba(50, 50, 93, 0.25) 0px 6px 12px -2px
+`

--- a/web/pages/components/MyFoldersAreaLogIn/MyFoldersAreaLogIn.tsx
+++ b/web/pages/components/MyFoldersAreaLogIn/MyFoldersAreaLogIn.tsx
@@ -1,0 +1,23 @@
+import { data } from './data';
+import { Text } from '../../../components';
+import { FolderSlider } from '../index';
+import * as S from './MyFoldersAreaLogIn.style';
+import theme from '../../../styles/themes';
+
+const MyFoldersAreaLogIn = () => {
+  return (
+    <S.Container>
+      <S.Header>
+        <Text color={theme.colors.main[0]}>Miral</Text>
+        <Text>
+          의<br />
+        </Text>
+        <Text>북마크 폴더 리스트</Text>
+      </S.Header>
+      <FolderSlider data={data} />
+      <S.StyledButton type="button">북마크 편집 &#62;</S.StyledButton>
+    </S.Container>
+  );
+};
+
+export default MyFoldersAreaLogIn;

--- a/web/pages/components/MyFoldersAreaLogIn/MyFoldersAreaLogIn.tsx
+++ b/web/pages/components/MyFoldersAreaLogIn/MyFoldersAreaLogIn.tsx
@@ -1,10 +1,14 @@
-import { data } from './data';
 import { Text } from '../../../components';
 import { FolderSlider } from '../index';
 import * as S from './MyFoldersAreaLogIn.style';
 import theme from '../../../styles/themes';
+import { Folder } from '../../../shared/DummyDataType';
 
-const MyFoldersAreaLogIn = () => {
+interface Props {
+  data: Folder[];
+}
+
+const MyFoldersAreaLogIn = ({ data }: Props) => {
   return (
     <S.Container>
       <S.Header>

--- a/web/pages/components/MyFoldersAreaLogIn/data.js
+++ b/web/pages/components/MyFoldersAreaLogIn/data.js
@@ -1,0 +1,500 @@
+export const data = [
+  {
+    id: 1,
+    image:
+      'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+    title: '일주일 자취 음식 레시피 모음! 어느새 나도 요리사?',
+    tags: [
+      { id: '1', text: '프론트엔드 개발자' },
+      { id: '2', text: '개발자' },
+      { id: '3', text: '프론트엔드' },
+    ],
+    user: {
+      image:
+        'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+      name: 'Miral',
+    },
+    createdAt: '2022-07-28',
+    likes: 154,
+    bookmarks: [
+      {
+        id: 1,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Naver Blog - 프론트엔드 학습 어쩌구 저쩌구',
+        url: 'https://www.naver.com/',
+      },
+      {
+        id: 2,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 3,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 4,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 5,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 6,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 7,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 8,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 9,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+    ],
+  },
+  {
+    id: 2,
+    image:
+      'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+    title: '프론트엔드 개발자를 위한 학습 로드맵',
+    tags: [
+      { id: '1', text: '프론트엔드 개발자' },
+      { id: '2', text: '개발자' },
+      { id: '3', text: '프론트엔드' },
+    ],
+    user: {
+      image:
+        'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+      name: 'Miral',
+    },
+    createdAt: '2022-07-28',
+    likes: 154,
+    bookmarks: [
+      {
+        id: 1,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Naver Blog - 프론트엔드 학습 어쩌구 저쩌구',
+        url: 'https://www.naver.com/',
+      },
+      {
+        id: 2,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 3,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 4,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 5,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 6,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 7,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 8,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 9,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+    ],
+  },
+  {
+    id: 3,
+    image:
+      'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+    title: '깃허브 유용한 레포 모음 - 개발자.ver',
+    tags: [
+      { id: '1', text: '프론트엔드 개발자' },
+      { id: '2', text: '개발자' },
+      { id: '3', text: '프론트엔드' },
+    ],
+    user: {
+      image:
+        'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+      name: 'Miral',
+    },
+    createdAt: '2022-07-28',
+    likes: 154,
+    bookmarks: [
+      {
+        id: 1,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Naver Blog - 프론트엔드 학습 어쩌구 저쩌구',
+        url: 'https://www.naver.com/',
+      },
+      {
+        id: 2,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 3,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 4,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 5,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 6,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 7,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 8,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 9,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+    ],
+  },
+  {
+    id: 4,
+    image:
+      'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+    title: '일주일 자취 음식 레시피 모음! 어느새 나도 요리사?',
+    tags: [
+      { id: '1', text: '프론트엔드 개발자' },
+      { id: '2', text: '개발자' },
+      { id: '3', text: '프론트엔드' },
+    ],
+    user: {
+      image:
+        'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+      name: 'Miral',
+    },
+    createdAt: '2022-07-28',
+    likes: 154,
+    bookmarks: [
+      {
+        id: 1,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Naver Blog - 프론트엔드 학습 어쩌구 저쩌구',
+        url: 'https://www.naver.com/',
+      },
+      {
+        id: 2,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 3,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 4,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 5,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 6,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 7,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 8,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 9,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+    ],
+  },
+  {
+    id: 5,
+    image:
+      'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+    title: '프론트엔드 개발자를 위한 학습 로드맵',
+    tags: [
+      { id: '1', text: '프론트엔드 개발자' },
+      { id: '2', text: '개발자' },
+      { id: '3', text: '프론트엔드' },
+    ],
+    user: {
+      image:
+        'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+      name: 'Miral',
+    },
+    createdAt: '2022-07-28',
+    likes: 154,
+    bookmarks: [
+      {
+        id: 1,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Naver Blog - 프론트엔드 학습 어쩌구 저쩌구',
+        url: 'https://www.naver.com/',
+      },
+      {
+        id: 2,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 3,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 4,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 5,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 6,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 7,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 8,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 9,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+    ],
+  },
+  {
+    id: 6,
+    image:
+      'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+    title: '깃허브 유용한 레포 모음 - 개발자.ver',
+    tags: [
+      { id: '1', text: '프론트엔드 개발자' },
+      { id: '2', text: '개발자' },
+      { id: '3', text: '프론트엔드' },
+    ],
+    user: {
+      image:
+        'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+      name: 'Miral',
+    },
+    createdAt: '2022-07-28',
+    likes: 154,
+    bookmarks: [
+      {
+        id: 1,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Naver Blog - 프론트엔드 학습 어쩌구 저쩌구',
+        url: 'https://www.naver.com/',
+      },
+      {
+        id: 2,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 3,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 4,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 5,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 6,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 7,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 8,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+      {
+        id: 9,
+        image:
+          'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
+        title: 'Baekjoon Online Judge',
+        url: 'https://www.acmicpc.net/',
+      },
+    ],
+  },
+];

--- a/web/pages/components/MyFoldersAreaLogIn/index.ts
+++ b/web/pages/components/MyFoldersAreaLogIn/index.ts
@@ -1,0 +1,3 @@
+import MyFoldersAreaLogIn from './MyFoldersAreaLogIn';
+
+export default MyFoldersAreaLogIn;

--- a/web/pages/components/index.ts
+++ b/web/pages/components/index.ts
@@ -1,3 +1,5 @@
 export { default as MyFoldersAreaLogOut } from './MyFoldersAreaLogOut';
 export { default as Category } from './Category';
 export { default as UseInfo } from './UseInfo';
+export { default as MyFoldersAreaLogIn } from './MyFoldersAreaLogIn';
+export { default as FolderSlider } from './FolderSlider';

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -1,11 +1,13 @@
 import type { NextPage } from 'next';
 import * as S from './index.style';
-import { MyFoldersAreaLogOut } from './components';
+import { MyFoldersAreaLogIn, MyFoldersAreaLogOut } from './components';
+import { allFolders } from '../shared/DummyData';
 
 const MainPage: NextPage = () => {
   return (
     <S.Div>
-      <MyFoldersAreaLogOut />
+      {/* <MyFoldersAreaLogOut /> */}
+      <MyFoldersAreaLogIn data={allFolders} />
     </S.Div>
   );
 };

--- a/web/public/icons/arrowLeft.svg
+++ b/web/public/icons/arrowLeft.svg
@@ -1,5 +1,5 @@
 <svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="20" cy="20" r="20" fill="#D9D9D9"/>
+<circle cx="20" cy="20" r="20" fill="#BDBDBD"/>
 <line x1="12.6313" y1="20.0511" x2="24.2614" y2="8.42105" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
 <line x1="12.5803" y1="19.6759" x2="24.2103" y2="31.306" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
 </svg>

--- a/web/public/icons/arrowRight.svg
+++ b/web/public/icons/arrowRight.svg
@@ -1,5 +1,5 @@
 <svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="20" cy="20" r="20" transform="rotate(-180 20 20)" fill="#D9D9D9"/>
+<circle cx="20" cy="20" r="20" transform="rotate(-180 20 20)" fill="#BDBDBD"/>
 <line x1="27.3687" y1="19.9489" x2="15.7386" y2="31.5789" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
 <line x1="27.4197" y1="20.3241" x2="15.7897" y2="8.69405" stroke="white" stroke-width="2.5" stroke-linecap="round"/>
 </svg>

--- a/web/shared/DummyDataType.ts
+++ b/web/shared/DummyDataType.ts
@@ -12,7 +12,7 @@ export interface SpecificUserFolders {
 }
 
 export interface Folder {
-  id: string | number;
+  id: number;
   title: string;
   image: string;
   content?: string;


### PR DESCRIPTION
### 📌 설명
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/59829606/182018031-73f8a1e2-ac87-4d13-95d7-71cd98f4cd01.png">

### 🎨 구현 내용
* 로그인 되었을 때 보여질 나의 폴더 리스트를 구현했습니다.
* 캐러셀을 이용해 자신이 메인에 보고싶은 폴더 리스트를 렌더링 합니다. 
  * 데이터가 3개보다 많을 때 반응형으로 구현했습니다.
  * 데이터가 3개 이하이면 그냥 중앙에 렌더링 합니다.

### ✅ 중점적으로 봐줬으면 하는 부분
* 카테고리 컴포넌트가 현재 수정중이기 때문에 아직 메인 페이지에는 렌더링 하지 않았습니다.
* tags가 단순한 string 배열이기 때문에 Tag 컴포넌트의 tagItems의 타입을 수정했습니다.
* 캐러셀을 집중적으로 리뷰해주셨으면 좋겠습니다.
### 🚀 연관된 이슈
closes #29 