### PR TITLE
Feat: TagSelector 컴포넌트 추가

### DIFF
--- a/web/components/Input/Input.tsx
+++ b/web/components/Input/Input.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { ChangeEventHandler } from 'react';
+import React, { KeyboardEventHandler, ChangeEventHandler } from 'react';
 import * as S from './Input.style';
 
 interface Props {
@@ -8,6 +7,7 @@ interface Props {
   placeholder: string;
   maxLength?: number;
   onChange?: ChangeEventHandler;
+  onKeyDown?: KeyboardEventHandler;
   ref?: React.Ref<HTMLInputElement>;
 }
 
@@ -17,7 +17,10 @@ const defaultProps = {
 };
 
 const Input = React.forwardRef<HTMLInputElement, Props>(
-  ({ children, placeholder, maxLength, onChange, type, ...styles }, ref) => {
+  (
+    { children, placeholder, maxLength, onChange, type, onKeyDown, ...styles },
+    ref,
+  ) => {
     return (
       <S.Wrapper>
         <S.Input
@@ -25,6 +28,7 @@ const Input = React.forwardRef<HTMLInputElement, Props>(
           placeholder={placeholder}
           maxLength={maxLength}
           onChange={onChange}
+          onKeyDown={onKeyDown}
           ref={ref}
           {...styles}
         />

--- a/web/components/Input/Input.tsx
+++ b/web/components/Input/Input.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { ChangeEventHandler } from 'react';
 import * as S from './Input.style';
 
@@ -7,6 +8,7 @@ interface Props {
   placeholder: string;
   maxLength?: number;
   onChange?: ChangeEventHandler;
+  ref?: React.Ref<HTMLInputElement>;
 }
 
 const defaultProps = {
@@ -14,27 +16,23 @@ const defaultProps = {
   placeholder: '검색어를 입력하세요.',
 };
 
-const Input = ({
-  children,
-  placeholder,
-  maxLength,
-  onChange,
-  type,
-  ...styles
-}: Props) => {
-  return (
-    <S.Wrapper>
-      <S.Input
-        type={type}
-        placeholder={placeholder}
-        maxLength={maxLength}
-        onChange={onChange}
-        {...styles}
-      />
-      <S.Action>{children}</S.Action>
-    </S.Wrapper>
-  );
-};
+const Input = React.forwardRef<HTMLInputElement, Props>(
+  ({ children, placeholder, maxLength, onChange, type, ...styles }, ref) => {
+    return (
+      <S.Wrapper>
+        <S.Input
+          type={type}
+          placeholder={placeholder}
+          maxLength={maxLength}
+          onChange={onChange}
+          ref={ref}
+          {...styles}
+        />
+        <S.Action>{children}</S.Action>
+      </S.Wrapper>
+    );
+  },
+);
 
 Input.defaultProps = defaultProps;
 

--- a/web/components/InputResult/InputResult.style.ts
+++ b/web/components/InputResult/InputResult.style.ts
@@ -1,7 +1,9 @@
 import styled from '@emotion/styled';
 
 interface Props {
-  inputResultVisible: boolean;
+  inputResultVisible?: boolean;
+  active?: boolean;
+  isDefault?: boolean;
 }
 
 export const List = styled.ul<Props>`
@@ -22,11 +24,12 @@ export const List = styled.ul<Props>`
   }
 `
 
-export const Item = styled.li`
+export const Item = styled.li<Props>`
   padding: 8px;
   border-radius: 8px;
   cursor: pointer;
+  background-color: ${({theme, active}) => active ? theme.colors.gray[5] : theme.colors.white[0]};
   &:hover {
-    background-color: ${(props) => props.theme.colors.gray[5]};
+    background-color: ${({theme, isDefault}) => isDefault ? theme.colors.white[0] : theme.colors.gray[5]};
   }
 `

--- a/web/components/InputResult/InputResult.style.ts
+++ b/web/components/InputResult/InputResult.style.ts
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+
+interface Props {
+  inputResultVisible: boolean;
+}
+
+export const List = styled.ul<Props>`
+  display: ${({inputResultVisible}) => inputResultVisible ? 'block' : 'none'};
+  max-height: 144px;
+  overflow: auto;
+  padding: 8px 14px;
+  border: 1px solid ${(props) => props.theme.colors.gray[4]};
+  border-radius: 0 0 6px 6px;
+
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+  &::-webkit-scrollbar-thumb {
+    height: 30%;
+    border-radius: 10px;
+    background-color: ${(props) => props.theme.colors.gray[4]};
+  }
+`
+
+export const Item = styled.li`
+  padding: 8px;
+  border-radius: 8px;
+  cursor: pointer;
+  &:hover {
+    background-color: ${(props) => props.theme.colors.gray[5]};
+  }
+`

--- a/web/components/InputResult/InputResult.tsx
+++ b/web/components/InputResult/InputResult.tsx
@@ -1,0 +1,31 @@
+import { MouseEventHandler } from 'react';
+import * as S from './InputResult.style';
+
+interface Props {
+  inputResultVisible: boolean;
+  inputResults: string[];
+  onClick?: MouseEventHandler;
+}
+
+const defaultProps = {
+  inputResultVisible: true,
+  inputResults: [],
+};
+
+const InputResult = ({ inputResultVisible, inputResults, onClick }: Props) => {
+  return (
+    <>
+      <S.List inputResultVisible={inputResultVisible}>
+        {inputResults.map((value) => (
+          <S.Item key={value} onClick={onClick}>
+            {value}
+          </S.Item>
+        ))}
+      </S.List>
+    </>
+  );
+};
+
+InputResult.defaultProps = defaultProps;
+
+export default InputResult;

--- a/web/components/InputResult/InputResult.tsx
+++ b/web/components/InputResult/InputResult.tsx
@@ -1,30 +1,40 @@
+import React from 'react';
 import { MouseEventHandler } from 'react';
 import * as S from './InputResult.style';
 
 interface Props {
+  active: number;
   inputResultVisible: boolean;
   inputResults: string[];
   onClick?: MouseEventHandler;
+  ref?: React.Ref<HTMLUListElement>;
+  placeholder?: string;
 }
 
 const defaultProps = {
   inputResultVisible: true,
-  inputResults: [],
+  placeholder: '일치하는 태그가 없습니다.',
 };
 
-const InputResult = ({ inputResultVisible, inputResults, onClick }: Props) => {
-  return (
-    <>
-      <S.List inputResultVisible={inputResultVisible}>
-        {inputResults.map((value) => (
-          <S.Item key={value} onClick={onClick}>
-            {value}
-          </S.Item>
-        ))}
-      </S.List>
-    </>
-  );
-};
+const InputResult = React.forwardRef<HTMLUListElement, Props>(
+  ({ active, inputResultVisible, inputResults, onClick, placeholder }, ref) => {
+    return (
+      <>
+        <S.List inputResultVisible={inputResultVisible} ref={ref}>
+          {inputResults.length !== 0 ? (
+            inputResults.map((value, index) => (
+              <S.Item key={value} active={active === index} onClick={onClick}>
+                {value}
+              </S.Item>
+            ))
+          ) : (
+            <S.Item isDefault={true}>{placeholder}</S.Item>
+          )}
+        </S.List>
+      </>
+    );
+  },
+);
 
 InputResult.defaultProps = defaultProps;
 

--- a/web/components/InputResult/index.ts
+++ b/web/components/InputResult/index.ts
@@ -1,0 +1,3 @@
+import InputResult from './InputResult';
+
+export default InputResult;

--- a/web/components/Tag/Tag.tsx
+++ b/web/components/Tag/Tag.tsx
@@ -4,26 +4,32 @@ import * as S from './Tag.style';
 interface Props {
   tagItems: string[];
   shrinking?: boolean;
+  handleRemoveTag?: (value: string) => void;
 }
 
-const Tag = ({ tagItems, shrinking = false }: Props) => {
+const Tag = ({ tagItems, shrinking = false, handleRemoveTag }: Props) => {
   return shrinking && tagItems.length > 3 ? (
     <S.TagWrapper>
       {tagItems.slice(0, 3).map((item, index) => (
-        <TagItem shrinking key={index}>
+        <TagItem shrinking key={index} handleRemoveTag={handleRemoveTag}>
           {item}
         </TagItem>
       ))}
-      <TagItem key={123}>{`+${tagItems.length - 3}`}</TagItem>
+      <TagItem>{`+${tagItems.length - 3}`}</TagItem>
     </S.TagWrapper>
   ) : (
     <S.TagWrapper>
       {tagItems.map((item, index) => (
-        <TagItem shrinking={shrinking} key={index}>
+        <TagItem
+          shrinking={shrinking}
+          key={index}
+          handleRemoveTag={handleRemoveTag}
+        >
           {item}
         </TagItem>
       ))}
     </S.TagWrapper>
   );
 };
+
 export default Tag;

--- a/web/components/Tag/TagItem/TagItem.style.ts
+++ b/web/components/Tag/TagItem/TagItem.style.ts
@@ -6,6 +6,7 @@ interface Props {
 }
 
 const ShrinkTag = ({ theme }: ThemeProps) => css`
+  display: inline-block;
   max-width: 80px;
   text-overflow: ellipsis;
   overflow: hidden;
@@ -14,7 +15,9 @@ const ShrinkTag = ({ theme }: ThemeProps) => css`
 `;
 
 export const TagItem = styled.div`
-  display: inline-block;
+  display: flex;
+  align-items: center;
+  gap: 8px;
   padding: 5px 10px;
   border-radius: 3px;
   color: ${({ theme }) => theme.colors.gray[0]};
@@ -23,3 +26,7 @@ export const TagItem = styled.div`
 
   ${({ shrinking }: Props) => shrinking && ShrinkTag}
 `;
+
+export const IconWrapper = styled.div`
+  cursor: pointer;
+`

--- a/web/components/Tag/TagItem/TagItem.tsx
+++ b/web/components/Tag/TagItem/TagItem.tsx
@@ -1,16 +1,28 @@
 import { MouseEventHandler } from 'react';
+import Icon from '../../Icon';
 import * as S from './TagItem.style';
 
 interface Props {
   children: string;
   onClick?: MouseEventHandler;
   shrinking?: boolean;
+  handleRemoveTag?: (value: string) => void;
 }
 
-const TagItem = ({ children, onClick, shrinking = false }: Props) => {
+const TagItem = ({
+  children,
+  onClick,
+  shrinking = false,
+  handleRemoveTag,
+}: Props) => {
   return (
     <S.TagItem shrinking={shrinking} onClick={onClick}>
       {children}
+      {handleRemoveTag && (
+        <S.IconWrapper onClick={() => handleRemoveTag(children)}>
+          <Icon name="x" size={9} />
+        </S.IconWrapper>
+      )}
     </S.TagItem>
   );
 };

--- a/web/components/TagSelector/TagSelector.style.ts
+++ b/web/components/TagSelector/TagSelector.style.ts
@@ -1,0 +1,6 @@
+import styled from '@emotion/styled';
+
+
+export const Container = styled.div`
+  width: 100%;
+`;

--- a/web/components/TagSelector/TagSelector.tsx
+++ b/web/components/TagSelector/TagSelector.tsx
@@ -1,0 +1,92 @@
+import React, { useRef, useState } from 'react';
+import { Input, InputResult, Tag } from '../index';
+import * as S from './TagSelector.style';
+
+interface Props {
+  selectedTag: string[];
+  setSelectedTag: (selectedTag: string[]) => void;
+}
+
+const TagSelector = ({ selectedTag, setSelectedTag, ...styles }: Props) => {
+  // Todo: api요청 혹은 전역 데이터로 관리
+  const tags = [
+    '개발',
+    '쇼핑',
+    '코딩',
+    '취미',
+    '창업',
+    '마케팅',
+    '개발 필터링 테스트',
+    '쇼핑 필터링 테스트',
+    '코딩 필터링 테스트',
+    '취미 필터링 테스트',
+    '창업 필터링 테스트',
+    '마케팅 필터링 테스트',
+  ];
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [autoCompleteSearch, setAutoCompleteSearch] = useState<string[]>([]);
+  const [inputResultVisible, setInputResultVisible] = useState(false);
+
+  const handleFilterInputValue = () => {
+    const keyword = inputRef.current!.value;
+    const filteredSearch = tags.filter((tag) => tag.indexOf(keyword) >= 0);
+
+    // 아무것도 입력하지 않았을 때
+    if (!keyword) {
+      setAutoCompleteSearch([]);
+      handleVisibleInputResult(false);
+      return;
+    }
+    // 자동완성된 결과가 없을 떄
+    handleVisibleInputResult(true);
+    if (filteredSearch.length === 0) {
+      return setAutoCompleteSearch(['일치하는 태그가 없습니다.']);
+    }
+    setAutoCompleteSearch(filteredSearch);
+  };
+
+  const handleClickResultItem = (e: React.MouseEvent<HTMLLIElement>) => {
+    handleAddTag(e);
+    handleResetSelector();
+  };
+
+  const handleResetSelector = () => {
+    inputRef.current!.value = '';
+    handleVisibleInputResult(false);
+  };
+
+  const handleAddTag = (e: React.MouseEvent<HTMLLIElement>) => {
+    const target = e.currentTarget;
+    const value = target.innerText;
+    const updatedData = new Set([...selectedTag, value]);
+    setSelectedTag(Array.from(updatedData));
+  };
+
+  const handleRemoveTag = (value: string) => {
+    const updatedData = selectedTag.filter((tag) => tag !== value);
+    setSelectedTag(updatedData);
+  };
+
+  const handleVisibleInputResult = (state: boolean) => {
+    setInputResultVisible(state);
+  };
+
+  return (
+    <S.Container {...styles}>
+      <Tag tagItems={selectedTag} handleRemoveTag={handleRemoveTag} />
+      <Input
+        type="text"
+        ref={inputRef}
+        placeholder="태그를 입력해 주세요! 클릭 혹은 엔터를 사용해서 입력할 수 있습니다."
+        onChange={handleFilterInputValue}
+      />
+      <InputResult
+        inputResultVisible={inputResultVisible}
+        inputResults={autoCompleteSearch}
+        onClick={handleClickResultItem}
+      />
+    </S.Container>
+  );
+};
+
+export default TagSelector;

--- a/web/components/TagSelector/TagSelector.tsx
+++ b/web/components/TagSelector/TagSelector.tsx
@@ -45,7 +45,9 @@ const TagSelector = ({ selectedTag, setSelectedTag, ...styles }: Props) => {
   };
 
   const handleClickResultItem = (e: React.MouseEvent<HTMLLIElement>) => {
-    handleAddTag(e);
+    const target = e.currentTarget;
+    const value = target.innerText;
+    handleAddTag(value);
     handleResetSelector();
   };
 
@@ -55,9 +57,7 @@ const TagSelector = ({ selectedTag, setSelectedTag, ...styles }: Props) => {
     setActiveItem(0);
   };
 
-  const handleAddTag = (e: React.MouseEvent<HTMLLIElement>) => {
-    const target = e.currentTarget;
-    const value = target.innerText;
+  const handleAddTag = (value: string) => {
     const updatedData = new Set([...selectedTag, value]);
     setSelectedTag(Array.from(updatedData));
   };
@@ -72,7 +72,7 @@ const TagSelector = ({ selectedTag, setSelectedTag, ...styles }: Props) => {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (!inputResultVisible) {
+    if (!inputResultVisible || e.keyCode === 229) {
       return;
     }
 
@@ -93,7 +93,7 @@ const TagSelector = ({ selectedTag, setSelectedTag, ...styles }: Props) => {
         }
         break;
       case 'Enter':
-        setSelectedTag([...selectedTag, autoCompleteSearch[activeItem]]);
+        handleAddTag(autoCompleteSearch[activeItem]);
         handleResetSelector();
         break;
       case 'Escape':
@@ -102,7 +102,7 @@ const TagSelector = ({ selectedTag, setSelectedTag, ...styles }: Props) => {
         break;
       default:
         setActiveItem(0);
-        break;
+      // break;
     }
   };
 

--- a/web/components/TagSelector/index.ts
+++ b/web/components/TagSelector/index.ts
@@ -1,0 +1,3 @@
+import TagSelector from './TagSelector';
+
+export default TagSelector;

--- a/web/components/index.ts
+++ b/web/components/index.ts
@@ -18,4 +18,5 @@ export { default as ImageUpload } from './ImageUpload';
 export { default as Profile } from './Profile';
 export { default as Comment } from './Comment';
 export { default as CommentInput } from './CommentInput';
-
+export { default as InputResult } from './InputResult'
+export { default as TagSelector } from './TagSelector'

--- a/web/shared/DummyData.ts
+++ b/web/shared/DummyData.ts
@@ -4,7 +4,8 @@ import { UserInfo, SpecificUserFolders, Folder } from './DummyDataType';
 export const myInfo: UserInfo = {
   email: 'example1@gmail.com',
   name: '익명의 사용자',
-  image: '',
+  image:
+    'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
   interest: ['개발', '쇼핑'],
 };
 
@@ -266,7 +267,7 @@ export const allFolders: Folder[] = [
     image:
       'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
     title: '일주일 자취 음식 레시피 모음! 어느새 나도 요리사?',
-    tags: ['코딩', '개발', '취미'],
+    tags: ['프론트엔드 개발자', '개발자', '프론트엔드'],
     user: {
       image:
         'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
@@ -376,7 +377,7 @@ export const allFolders: Folder[] = [
     image:
       'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
     title: '프론트엔드 개발자를 위한 학습 로드맵',
-    tags: ['코딩', '개발', '취미'],
+    tags: ['프론트엔드 개발자', '개발자', '프론트엔드'],
     user: {
       image:
         'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
@@ -477,7 +478,7 @@ export const allFolders: Folder[] = [
     image:
       'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
     title: '깃허브 유용한 레포 모음 - 개발자.ver',
-    tags: ['코딩', '개발', '취미'],
+    tags: ['프론트엔드 개발자', '개발자', '프론트엔드'],
     user: {
       image:
         'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
@@ -578,7 +579,7 @@ export const allFolders: Folder[] = [
     image:
       'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
     title: '일주일 자취 음식 레시피 모음! 어느새 나도 요리사?',
-    tags: ['코딩', '개발', '취미'],
+    tags: ['프론트엔드 개발자', '개발자', '프론트엔드'],
     user: {
       image:
         'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
@@ -679,7 +680,7 @@ export const allFolders: Folder[] = [
     image:
       'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
     title: '프론트엔드 개발자를 위한 학습 로드맵',
-    tags: ['코딩', '개발', '취미'],
+    tags: ['프론트엔드 개발자', '개발자', '프론트엔드'],
     user: {
       image:
         'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
@@ -780,7 +781,7 @@ export const allFolders: Folder[] = [
     image:
       'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
     title: '깃허브 유용한 레포 모음 - 개발자.ver',
-    tags: ['코딩', '개발', '취미'],
+    tags: ['프론트엔드 개발자', '개발자', '프론트엔드'],
     user: {
       image:
         'https://images.unsplash.com/photo-1515041219749-89347f83291a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1074&q=80',
@@ -877,3 +878,4 @@ export const allFolders: Folder[] = [
     ],
   },
 ];
+

--- a/web/shared/DummyDataType.ts
+++ b/web/shared/DummyDataType.ts
@@ -7,11 +7,6 @@ export interface UserInfo {
   interest?: string[];
 }
 
-export interface Tag {
-  id: number;
-  text: string;
-}
-
 export interface SpecificUserFolders {
   folders: Folder[];
   user: UserInfo;


### PR DESCRIPTION
### 📌 설명
<img width="722" alt="image" src="https://user-images.githubusercontent.com/59829606/182372216-dfa114ca-6706-438a-8523-f86f46d52c80.png">

### 🎨 구현 내용
#### TagSelector
* 부모 컴포넌트로부터 seletedTag, setSelectedTag를 받습니다.
  * useState로 선택된 태그를 관리
* Input, InputResult의 부모 컴포넌트
  * useRef로 Input 컴포넌트의 value를 관리
  * useRef로 InputResult 컴포넌트의 List 키보드로 이동 구현
#### InputResult
* 부모 컴포넌트로부터 active, ref, inputResultVisible, inputResults, onClick을 받습니다.
  * active: 선택된 아이템을 구분하기 위해 사용
  * ref: useRef로 InputResult 컴포넌트의 List 키보드로 이동 구현
  * inputResultVisible: 검색 결과가 없을 때 result를 보여주지 않습니다.
  * inputResults: 검색 결과
  * onClick: 아이템 클릭 시 이벤트
#### Input
* 부모로부터 ref를 받기 위해 forwardRef추가
* 키보드 이벤트를 위해 onKeyDown prop 추가
####Tag
* TagItem을 삭제하기 위해 handleRmoveTag prop 추가
#### TagItem
* TagItem을 삭제하기 위해 handleRmoveTag prop 추가
* Icon 추가
### ✅ 중점적으로 봐줬으면 하는 부분
* 이벤트 핸들러가 생각보다 많이 들어가서 간소화 할 방법이 있을까요?
* 디바운스는 아직 미구현 입니다.

### 예시 코드
```js
import type { NextPage } from 'next';
import * as S from './index.style';
import TagSelector from '../components/TagSelector';
import { useState } from 'react';

const MainPage: NextPage = () => {
  // 상위 컴포넌트에서 사용할 state
  const [selectedTag, setSelectedTag] = useState<string[]>([]);
  console.log(selectedTag);
  return (
    <S.Div>
      <TagSelector selectedTag={selectedTag} setSelectedTag={setSelectedTag} />
    </S.Div>
  );
};

export default MainPage;
```


### 🚀 연관된 이슈
closes #42 