### PR TITLE
Feat: Recoil + FolderSlider 버그

### DIFF
--- a/web/components/Layout.tsx
+++ b/web/components/Layout.tsx
@@ -1,19 +1,32 @@
 import { ThemeProvider } from '@emotion/react';
+import { useEffect } from 'react';
+import { useSetRecoilState } from 'recoil';
+import { loginStatus } from '../recoil/authentication';
 import GlobalStyle from '../styles/GlobalStyle';
 import theme from '../styles/themes';
 import Footer from './Footer';
 import NavigationBar from './NavigationBar';
 
 interface Props {
+  token: string;
   children: React.ReactNode;
 }
 
-const Layout = ({ children }: Props) => {
+const Layout = ({ token, children }: Props) => {
+  const setIsLoggedIn = useSetRecoilState(loginStatus);
+  useEffect(() => {
+    if (token) {
+      setIsLoggedIn(true);
+    } else {
+      setIsLoggedIn(false);
+    }
+  }, []);
+
   return (
     <>
       <ThemeProvider theme={theme}>
         <GlobalStyle />
-        <NavigationBar />
+        <NavigationBar token={token} />
         {children}
         <Footer />
       </ThemeProvider>

--- a/web/components/Modal/Login/Login.tsx
+++ b/web/components/Modal/Login/Login.tsx
@@ -1,12 +1,22 @@
 import { MouseEventHandler } from 'react';
 import { Button, Input, Icon } from '../../index';
+import { useSetRecoilState } from 'recoil';
+
 import * as S from '../Modal.style';
+import { loginStatus } from '../../../recoil/authentication';
+import { setCookies } from '../../../util/cookies';
 
 interface Props {
   switchFunc?: MouseEventHandler;
 }
 
 const Login = ({ switchFunc }: Props) => {
+  const setLoginStatus = useSetRecoilState(loginStatus);
+  const handleLogin = () => {
+    setCookies('token', 'tempToken', '/');
+    setLoginStatus(true);
+  };
+
   return (
     <S.InnerContainer>
       <S.Title>
@@ -21,7 +31,9 @@ const Login = ({ switchFunc }: Props) => {
         </S.LoggedButton>
       </S.InputContainer>
       <S.ButtonContainer>
-        <Button type="button">로그인</Button>
+        <Button type="button" onClick={handleLogin}>
+          로그인
+        </Button>
       </S.ButtonContainer>
       {/* <S.ButtonContainer>
         <Button type="button">Kakao 로그인</Button>

--- a/web/components/NavigationBar/NavigationBar.tsx
+++ b/web/components/NavigationBar/NavigationBar.tsx
@@ -1,23 +1,39 @@
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { Avatar, Button, Icon, Text, Modal } from '../index';
+import { useRecoilState } from 'recoil';
+import { loginStatus } from '../../recoil/authentication';
+import nookies from 'nookies';
 import * as S from './NavigationBar.style';
+import { removeCookie } from '../../util/cookies';
+import { NextPageContext } from 'next';
 
-interface Props {
-  isLogin: boolean;
-}
-
-const defaultProps = {
-  isLogin: false,
+export const getServerSideProps = (ctx: NextPageContext) => {
+  const { token } = nookies.get(ctx);
+  return {
+    props: {
+      token,
+    },
+  };
 };
 
-const NavigationBar = ({ isLogin }: Props) => {
-  const [isLoggedIn, setIsLoggedIn] = useState(isLogin);
+interface Props {
+  token: string;
+}
+
+const NavigationBar = ({ token }: Props) => {
+  const [loginState, setLoginState] = useRecoilState(loginStatus);
+  const [isLoggedIn, setIsLoggedIn] = useState(!!token);
   const [showLoginModal, setShowLoginModal] = useState(false);
   const [showSignUpModal, setShowSignUpModal] = useState(false);
 
   const handleLogin = () => {
     setShowLoginModal(!showLoginModal);
+  };
+
+  const handleLogout = () => {
+    removeCookie('token');
+    setLoginState(false);
   };
 
   const handleSignUp = () => {
@@ -30,8 +46,8 @@ const NavigationBar = ({ isLogin }: Props) => {
   };
 
   useEffect(() => {
-    setIsLoggedIn(isLogin);
-  }, [isLogin]);
+    setIsLoggedIn(loginState);
+  }, [loginState]);
 
   return (
     <>
@@ -69,6 +85,9 @@ const NavigationBar = ({ isLogin }: Props) => {
                 <Button type="button" version="navBar">
                   새 폴더 작성
                 </Button>
+                <Button type="button" version="navBar" onClick={handleLogout}>
+                  로그아웃
+                </Button>
               </S.UserContainer>
             </>
           ) : (
@@ -87,7 +106,5 @@ const NavigationBar = ({ isLogin }: Props) => {
     </>
   );
 };
-
-NavigationBar.defaultProps = defaultProps;
 
 export default NavigationBar;

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,6 +13,7 @@
         "axios": "^0.27.2",
         "emotion-reset": "^3.0.1",
         "next": "12.2.2",
+        "nookies": "^2.5.2",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-hook-form": "^7.33.1",
@@ -17846,6 +17847,23 @@
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
       "license": "MIT"
     },
+    "node_modules/nookies": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/nookies/-/nookies-2.5.2.tgz",
+      "integrity": "sha512-x0TRSaosAEonNKyCrShoUaJ5rrT5KHRNZ5DwPCuizjgrnkpE5DRf3VL7AyyQin4htict92X1EQ7ejDbaHDVdYA==",
+      "dependencies": {
+        "cookie": "^0.4.1",
+        "set-cookie-parser": "^2.4.6"
+      }
+    },
+    "node_modules/nookies/node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -20630,6 +20648,11 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
+      "integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ=="
     },
     "node_modules/set-value": {
       "version": "2.0.1",
@@ -36004,6 +36027,22 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
     },
+    "nookies": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/nookies/-/nookies-2.5.2.tgz",
+      "integrity": "sha512-x0TRSaosAEonNKyCrShoUaJ5rrT5KHRNZ5DwPCuizjgrnkpE5DRf3VL7AyyQin4htict92X1EQ7ejDbaHDVdYA==",
+      "requires": {
+        "cookie": "^0.4.1",
+        "set-cookie-parser": "^2.4.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+          "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+        }
+      }
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -37974,6 +38013,11 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
+    },
+    "set-cookie-parser": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
+      "integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ=="
     },
     "set-value": {
       "version": "2.0.1",

--- a/web/package.json
+++ b/web/package.json
@@ -16,6 +16,7 @@
     "axios": "^0.27.2",
     "emotion-reset": "^3.0.1",
     "next": "12.2.2",
+    "nookies": "^2.5.2",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.33.1",

--- a/web/pageComponents/mainPageComponents/components/FolderSlider/FolderSlider.tsx
+++ b/web/pageComponents/mainPageComponents/components/FolderSlider/FolderSlider.tsx
@@ -65,7 +65,7 @@ const FolderSlider = ({ data }: Props) => {
 
     sliderRef.current.style.transition = `all 0.5s `;
     if (winX > 660) {
-      if (currentIndex > bookmarkCount - 3) {
+      if (winX > 1280 && currentIndex > bookmarkCount - 3) {
         setCurrentIndex(0);
         sliderRef.current.style.transform = `translateX(-150px)`;
         return;

--- a/web/pages/_app.tsx
+++ b/web/pages/_app.tsx
@@ -1,12 +1,21 @@
-import type { AppProps } from 'next/app';
+import { RecoilRoot } from 'recoil';
+import type { AppContext, AppProps } from 'next/app';
 import Layout from '../components/Layout';
+import nookies from 'nookies';
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <Layout>
-      <Component {...pageProps} />
-    </Layout>
+    <RecoilRoot>
+      <Layout {...pageProps}>
+        <Component {...pageProps} />
+      </Layout>
+    </RecoilRoot>
   );
 }
+
+MyApp.getInitialProps = async (appContext: AppContext) => {
+  const { token } = nookies.get(appContext.ctx);
+  return { pageProps: { token } };
+};
 
 export default MyApp;

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -1,6 +1,5 @@
-import type { NextPage } from 'next';
+import type { NextPageContext } from 'next';
 import * as S from '../styles/pageStyles/index.style';
-
 import { allFolders } from '../shared/DummyData';
 import {
   MainCategory,
@@ -8,12 +7,34 @@ import {
   MyFoldersAreaLogOut,
   UseInfo,
 } from '../pageComponents/mainPageComponents/components';
+import { useRecoilValue } from 'recoil';
+import { loginStatus } from '../recoil/authentication';
+import nookies from 'nookies';
+import { useEffect, useState } from 'react';
 
-const MainPage: NextPage = () => {
-  const isLogined = true;
+export const getServerSideProps = (ctx: NextPageContext) => {
+  const { token } = nookies.get(ctx);
+  if (token) {
+    return { props: { token } };
+  }
+  return { props: {} };
+};
+
+interface Props {
+  token: string;
+}
+
+const MainPage = ({ token }: Props) => {
+  const [isLoggedIn, setIsLoggedIn] = useState(!!token);
+  const loginState = useRecoilValue(loginStatus);
+
+  useEffect(() => {
+    setIsLoggedIn(loginState);
+  }, [loginState]);
+
   return (
     <S.Container>
-      {isLogined ? (
+      {isLoggedIn ? (
         <MyFoldersAreaLogIn data={allFolders} />
       ) : (
         <MyFoldersAreaLogOut />

--- a/web/recoil/authentication.tsx
+++ b/web/recoil/authentication.tsx
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const loginStatus = atom({
+  key: 'LoginStatus',
+  default: false,
+});

--- a/web/recoil/user.tsx
+++ b/web/recoil/user.tsx
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const userInfo = atom({
+  key: 'userInfo',
+  default: {},
+});

--- a/web/util/cookies.tsx
+++ b/web/util/cookies.tsx
@@ -1,0 +1,35 @@
+import nookies, { parseCookies } from 'nookies';
+
+export const setCookies = (key: string, value: string, path: string) => {
+  try {
+    nookies.set(null, key, value, { path });
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const getCookie = (key: string) => {
+  const cookie = parseCookies();
+  try {
+    if (cookie && cookie[key]) {
+      return cookie[key];
+    }
+    console.error('존재하지 않는 쿠키 입니다.');
+    return false;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const removeCookie = (key: string) => {
+  try {
+    if (getCookie(key)) {
+      nookies.destroy(null, key, { path: '/' });
+      return;
+    }
+    console.error('존재하지 않는 쿠키 입니다.');
+    return false;
+  } catch (error) {
+    console.error(error);
+  }
+};


### PR DESCRIPTION
### 📌 설명
<!-- - 결과물(이미지 또는 움짤 참조할 것)
- 문제가 무엇인지에 대하여 분명하고 간결한 Description (이 PR을 통해 해결하는 문제)
- 문제를 해결하기 위해 도입한 개념, 방안 -->
로그인 유지, 전역 데이터
### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->
- nookies, recoil을 사용하여 로그인 유지를 구현했습니다.
- getInitialProps를 사용하여 token을 받고 조건부 렌더링을 했습니다.
- token 여부에 따라 loginStatus를 변경하여 이후에 로그인, 로그아웃 버튼을 눌렀을 때 조건부 렌더링에 사용할 수 있습니다.
- folderSlider가 1280px보다 크고 bookMarCount - 3보다 currentIndex가 클 때 currentIndex를 초기화 하도록 수정했습니다.
### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->
- SSR이 익숙하지 않아 로그인 유지를 제대로 구현했는지 모르겠습니다.
### 🚀 연관된 이슈
Closes #75 