### PR TITLE
Feat: 폴더 필터링 api 연동

### DIFF
--- a/web/apis/FolderAPI.ts
+++ b/web/apis/FolderAPI.ts
@@ -11,15 +11,19 @@ import {
   FolderCreateOrUpdate,
   PinnedFolder,
 } from '../types/folder';
-import { FOLDERS, USER } from './url';
+import { FOLDERS, LIKES, USER } from './url';
 
 // 폴더 리스트 전체 조회 (페이지, 정렬)
-export const getFolderList = async ({ page, size, sort }: GetFolderList) => {
+export const getFolderList = async (
+  { page, size, sort }: GetFolderList,
+  title?: any,
+) => {
   const res = await axios.get(`${FOLDERS}`, {
     params: {
       page,
       size,
       sort,
+      title,
     },
   });
 
@@ -28,14 +32,13 @@ export const getFolderList = async ({ page, size, sort }: GetFolderList) => {
 };
 
 // 특정 사용자 폴더리스트 조회
-export const getUserFolderList = async ({
-  id,
-  isPrivate,
-  page,
-  size,
-  sort,
-}: GetUserFolderList) => {
+export const getUserFolderList = async (
+  { id, isPrivate, page, size, sort }: GetUserFolderList,
+  token?: string,
+) => {
+  const tokenData = token ? { 'Access-Token': token } : null;
   const res = await axios.get(`${FOLDERS}${USER}/${id}`, {
+    headers: tokenData,
     params: {
       isPrivate,
       page,
@@ -73,6 +76,60 @@ export const getPinnedFolder = async (token: string) => {
   });
 
   return res as unknown as PinnedFolder;
+};
+
+// 루트 태그로 전체 폴더 조회
+export const getRootTagFolder = async (
+  { page, size, sort }: GetFolderList,
+  rootTag: string,
+) => {
+  const res = await axios.get(`${FOLDERS}/root-tag`, {
+    params: {
+      page,
+      size,
+      sort,
+    },
+    data: {
+      rootTag,
+    },
+  });
+  console.log(res);
+  return res as unknown as AllFolderList;
+};
+
+// 하위 태그로 전체 폴더 조회
+export const getTagFolder = async (
+  { page, size, sort }: GetFolderList,
+  tag: any,
+) => {
+  const res = await axios.get(`${FOLDERS}/tag`, {
+    params: {
+      page,
+      size,
+      sort,
+    },
+    data: {
+      tag,
+    },
+  });
+
+  return res as unknown as AllFolderList;
+};
+
+// 좋아요 눌른 폴더 조회
+export const getLikeFolder = async (
+  { page, size, sort }: GetFolderList,
+  id: number,
+) => {
+  const res = await axios.get(`${LIKES}/${id}`, {
+    params: {
+      page,
+      size,
+      sort,
+    },
+  });
+
+  return res as unknown as AllFolderList;
 };
 
 // 폴더 생성 (북마크까지) => 미개발

--- a/web/apis/FolderAPI.ts
+++ b/web/apis/FolderAPI.ts
@@ -83,33 +83,26 @@ export const getRootTagFolder = async (
   { page, size, sort }: GetFolderList,
   rootTag: string,
 ) => {
-  const res = await axios.get(`${FOLDERS}/root-tag`, {
+  const res = await axios.get(`${FOLDERS}/root-tag/${rootTag}}`, {
     params: {
       page,
       size,
       sort,
     },
-    data: {
-      rootTag,
-    },
   });
-  console.log(res);
   return res as unknown as AllFolderList;
 };
 
 // 하위 태그로 전체 폴더 조회
 export const getTagFolder = async (
   { page, size, sort }: GetFolderList,
-  tag: any,
+  tag: string,
 ) => {
-  const res = await axios.get(`${FOLDERS}/tag`, {
+  const res = await axios.get(`${FOLDERS}/tag/${tag}`, {
     params: {
       page,
       size,
       sort,
-    },
-    data: {
-      tag,
     },
   });
 

--- a/web/apis/TagAPI.ts
+++ b/web/apis/TagAPI.ts
@@ -1,0 +1,9 @@
+import axios from '.';
+import { TagType } from '../types';
+import { TAGS } from './url';
+
+export const getTag = async () => {
+  const res = await axios.get(`${TAGS}`);
+
+  return res as unknown as TagType;
+};

--- a/web/apis/url.ts
+++ b/web/apis/url.ts
@@ -24,3 +24,6 @@ export const LIKES = '/likes';
 // emails
 export const EMAIL = '/emails';
 export const VERIFY_EMAIL_KEY = '/certification';
+
+// tag
+export const TAGS = '/tags';

--- a/web/components/Card/Card.style.ts
+++ b/web/components/Card/Card.style.ts
@@ -4,6 +4,7 @@ import Text from '../Text';
 interface Props {
   version?: string;
   isPinned?: boolean;
+  isPrivate?: boolean;
   reverseCard?: boolean;
 }
 
@@ -14,7 +15,7 @@ export const Container = styled.div`
 export const Card = styled.div<Props>`
   overflow: hidden;
   width: ${({ version }) => (version === 'default' ? '300px' : '340px')};
-  height: auto;
+  height: ${({ version }) => (version === 'default' ? '384px' : '369px')};
   border-radius: 10px;
   box-shadow: rgba(50, 50, 93, 0.25) 0px 6px 12px -2px,
     rgba(0, 0, 0, 0.3) 0px 3px 7px -3px;
@@ -65,10 +66,11 @@ export const StatusWrapper = styled.div`
   width: 65px;
 `;
 
-export const StatusText = styled(Text)`
+export const StatusText = styled(Text)<Props>`
   padding: 2px 10px;
   font-size: ${({ theme }) => theme.fontSize.b[1]};
-  color: ${({ theme }) => theme.colors.gray[3]};
+  color: ${({ theme, isPrivate }) =>
+    isPrivate ? theme.colors.main[0] : theme.colors.gray[3]};
   font-weight: 400;
 `;
 

--- a/web/components/Card/Card.tsx
+++ b/web/components/Card/Card.tsx
@@ -1,14 +1,12 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import theme from '../../styles/themes';
 import { Avatar, Icon, Text, Tag } from '../index';
 import CardBack from './CardBack/CardBack';
 import * as S from './Card.style';
 import { Folder } from '../../shared/DummyDataType';
-import { getFolder } from '../../apis/FolderAPI';
-import { SpecificFolder } from '../../types';
 
 interface Props {
   data: Folder;
@@ -63,7 +61,11 @@ const Card = ({ data, version, shrinking, ...styles }: Props) => {
             )}
             {version === 'myCard' && (
               <S.StatusWrapper>
-                <S.StatusText>Public</S.StatusText>
+                {data.isPrivate ? (
+                  <S.StatusText isPrivate={true}>Private</S.StatusText>
+                ) : (
+                  <S.StatusText>Public</S.StatusText>
+                )}
               </S.StatusWrapper>
             )}
             <S.TitleWrapper>

--- a/web/components/Card/Card.tsx
+++ b/web/components/Card/Card.tsx
@@ -7,6 +7,8 @@ import { Avatar, Icon, Text, Tag } from '../index';
 import CardBack from './CardBack/CardBack';
 import * as S from './Card.style';
 import { Folder } from '../../shared/DummyDataType';
+import { useRecoilValue } from 'recoil';
+import { userInfo } from '../../recoil/user';
 
 interface Props {
   data: Folder;
@@ -27,6 +29,8 @@ const Card = ({ data, version, shrinking, ...styles }: Props) => {
   const router = useRouter();
   const [reverseCard, setReverseCard] = useState(false);
   const { bookmarks } = data;
+  const getUserInfo: any = useRecoilValue(userInfo);
+  const loginUserId = getUserInfo?.user?.id;
 
   const handleRotateCard = () => {
     setReverseCard(!reverseCard);
@@ -36,6 +40,19 @@ const Card = ({ data, version, shrinking, ...styles }: Props) => {
     router.push(`/folderdetail/${data.id}`);
   };
 
+  const pinIcon = () => {
+    const path = router.pathname.split('/')[1];
+    if (isPinned && path === 'user') {
+      const id = parseInt(router.query.id.toString());
+      if (id === loginUserId) {
+        return (
+          <S.IconWrapper>
+            <Icon name="pin_blue_ic" size={25} />
+          </S.IconWrapper>
+        );
+      }
+    }
+  };
   return (
     <S.Container>
       <S.Card version={version} reverseCard={reverseCard} {...styles}>
@@ -54,11 +71,12 @@ const Card = ({ data, version, shrinking, ...styles }: Props) => {
             />
           </S.ImageWrapper>
           <S.Content version={version}>
-            {isPinned && (
+            {pinIcon()}
+            {/* {isPinned && (
               <S.IconWrapper>
                 <Icon name="pin_blue_ic" size={25} />
               </S.IconWrapper>
-            )}
+            )} */}
             {version === 'myCard' && (
               <S.StatusWrapper>
                 {data.isPrivate ? (

--- a/web/components/Category/Category.tsx
+++ b/web/components/Category/Category.tsx
@@ -29,7 +29,7 @@ const Category = ({
       </S.TabWrapper>
       <S.CategoryCardWrapper>
         {isLoading ? (
-          <Skeleton width={340} height={400} repeat={data.length} />
+          <Skeleton width={340} height={369} repeat={data.length} />
         ) : (
           data.map((item: any) => (
             <Card shrinking key={item.id} version={cardVersion} data={item} />

--- a/web/components/NavigationBar/NavigationBar.tsx
+++ b/web/components/NavigationBar/NavigationBar.tsx
@@ -52,13 +52,13 @@ const NavigationBar = ({ token }: Props) => {
           <S.Nav>
             <Link
               href={{
-                pathname: '/folderlist/explore/all',
+                pathname: `${PAGE_URL.LIST}`,
                 query: {
-                  mainTag: 'all',
-                  subTag: 'all',
+                  mainTag: '전체 카테고리',
+                  subTag: '전체 카테고리',
                 },
               }}
-              as={'/folderlist/explore/all'}
+              as={`${PAGE_URL.LIST}/explore/all`}
               passHref
             >
               <S.NavItem>북마크리스트</S.NavItem>

--- a/web/components/NavigationBar/NavigationBar.tsx
+++ b/web/components/NavigationBar/NavigationBar.tsx
@@ -58,7 +58,7 @@ const NavigationBar = ({ token }: Props) => {
                   subTag: '전체 카테고리',
                 },
               }}
-              as={`${PAGE_URL.LIST}/explore/all`}
+              as={`${PAGE_URL.LIST}/explore/전체 카테고리`}
               passHref
             >
               <S.NavItem>북마크리스트</S.NavItem>

--- a/web/components/SearchBar/SearchBar.tsx
+++ b/web/components/SearchBar/SearchBar.tsx
@@ -4,6 +4,7 @@ import Icon from '../Icon';
 import { Dispatch, SetStateAction, useRef } from 'react';
 import { useEffect } from 'react';
 import Router from 'next/router';
+import { PAGE_URL } from '../../constants/url.constants';
 
 interface Props {
   setShowSearchBar: Dispatch<SetStateAction<boolean>>;
@@ -22,7 +23,15 @@ const SearchBar = ({ setShowSearchBar }: Props) => {
       alert('올바른 검색어를 입력해주세요.');
       return;
     }
-    Router.push(`/folderlist/search/${value}`);
+    Router.push(
+      {
+        pathname: `${PAGE_URL.LIST}`,
+        query: {
+          search: value,
+        },
+      },
+      `${PAGE_URL.LIST}/search/${value}`,
+    );
   };
 
   useEffect(() => {

--- a/web/pageComponents/folderlistComponents/components/TagCategory/TagCategory.tsx
+++ b/web/pageComponents/folderlistComponents/components/TagCategory/TagCategory.tsx
@@ -1,9 +1,12 @@
 import Router, { useRouter } from 'next/router';
-import { useState } from 'react';
-import { TagDummyData } from '../../../../shared/tagDummyData';
+import { useEffect, useState } from 'react';
+import { getTag } from '../../../../apis/TagAPI';
+import { PAGE_URL } from '../../../../constants/url.constants';
+import { TagType } from '../../../../types';
 import * as S from './TagCategory.style';
 
 export const TagCategory = () => {
+  const [tags, setTags] = useState([]);
   const router = useRouter();
   const [selectMainTag, setSelectMainTag] = useState(router.query.mainTag);
   const [visibleSubTagList, setVisibleSubTagList] = useState(
@@ -11,54 +14,61 @@ export const TagCategory = () => {
   );
 
   const handleSelectMainTag = (mainTag: string) => {
-    if (mainTag === 'all') {
-      handleSelectSubTag(mainTag);
+    if (mainTag === '전체 카테고리') {
+      setSelectMainTag('전체 카테고리');
+      handleSelectSubTag('전체 카테고리', '전체 카테고리');
       return;
     }
     setSelectMainTag(mainTag);
     setVisibleSubTagList(mainTag);
   };
 
-  const handleSelectSubTag = (subTag: string) => {
+  const handleSelectSubTag = (mainTag: string, subTag: string) => {
     Router.push(
       {
-        pathname: `/folderlist/explore/${subTag}`,
+        pathname: `${PAGE_URL.LIST}`,
         query: {
-          mainTag: selectMainTag,
+          mainTag,
           subTag,
         },
       },
-      `/folderlist/explore/${subTag}`,
+      `${PAGE_URL.LIST}/explore/${subTag}`,
     );
     setVisibleSubTagList('');
   };
+
+  useEffect(() => {
+    const fetch = async () => {
+      try {
+        const res: TagType = await getTag();
+        setTags(res.tags);
+      } catch {
+        throw new Error('API 요청중 에러 발생');
+      }
+    };
+    fetch();
+  }, []);
 
   return (
     <S.Container>
       <S.Header>태그 리스트</S.Header>
       <S.MainTagList>
-        <S.MainTag
-          active={selectMainTag === 'all'}
-          onClick={() => handleSelectMainTag('all')}
-        >
-          🌈 전체 카테고리
-        </S.MainTag>
-        {TagDummyData.map((mainTag, idx) => (
-          <S.TagConatiner key={mainTag.value} idx={idx + 2}>
+        {tags.map((tag, idx) => (
+          <S.TagConatiner key={tag.rootTag} idx={idx + 1}>
             <S.MainTag
-              active={selectMainTag === mainTag.value}
-              onClick={() => handleSelectMainTag(mainTag.value)}
+              active={selectMainTag === tag.rootTag}
+              onClick={() => handleSelectMainTag(tag.rootTag)}
             >
-              {mainTag.main}
+              {tag.rootTag}
             </S.MainTag>
-            {mainTag.sub.length > 0 && (
-              <S.SubTagList visible={visibleSubTagList === mainTag.value}>
-                {mainTag.sub.map((subTag) => (
+            {tag.subTags.length > 0 && (
+              <S.SubTagList visible={visibleSubTagList === tag.rootTag}>
+                {tag.subTags.map((subTag: string) => (
                   <S.SubTag
-                    key={subTag.value}
-                    onClick={() => handleSelectSubTag(subTag.value)}
+                    key={subTag}
+                    onClick={() => handleSelectSubTag(tag.rootTag, subTag)}
                   >
-                    {subTag.name}
+                    {subTag}
                   </S.SubTag>
                 ))}
               </S.SubTagList>

--- a/web/pageComponents/mainPageComponents/components/MainCategory/MainCategory.tsx
+++ b/web/pageComponents/mainPageComponents/components/MainCategory/MainCategory.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { AllFolderList, TabType } from '../../../../types';
 import { getFolderList } from '../../../../apis/FolderAPI';
+import { PAGE_URL } from '../../../../constants/url.constants';
 
 const MainCategory = () => {
   const tabItems = [
@@ -20,13 +21,13 @@ const MainCategory = () => {
   const moveFolderListPage = () => {
     router.push(
       {
-        pathname: '/folderlist/explore/all',
+        pathname: `${PAGE_URL.LIST}`,
         query: {
-          mainTag: 'all',
-          subTag: 'all',
+          mainTag: '전체 카테고리',
+          subTag: '전체 카테고리',
         },
       },
-      '/folderlist/explore/all',
+      `${PAGE_URL.LIST}/explore/전체 카테고리`,
     );
   };
 

--- a/web/pageComponents/mainPageComponents/components/MyFoldersAreaLogIn/MyFoldersAreaLogIn.tsx
+++ b/web/pageComponents/mainPageComponents/components/MyFoldersAreaLogIn/MyFoldersAreaLogIn.tsx
@@ -46,7 +46,9 @@ const MyFoldersAreaLogIn = () => {
         objectPosition="center"
       />
       <S.Header>
-        <Text color={theme.colors.main[0]}>Miral</Text>
+        <Text color={theme.colors.main[0]}>
+          {getUserInfo?.user?.name || '익명의사용자'}
+        </Text>
         <Text>
           의<br />
         </Text>

--- a/web/pages/folderlist/explore/[subTag].tsx
+++ b/web/pages/folderlist/explore/[subTag].tsx
@@ -1,26 +1,49 @@
-import { useRouter } from 'next/router';
-import FolderListDummy from '../../../shared/folderListPageDummy';
-import {
-  FolderList,
-  TagCategory,
-} from '../../../pageComponents/folderlistComponents/components';
-import styled from '@emotion/styled';
+// import { useRouter } from 'next/router';
+// import FolderListDummy from '../../../shared/folderListPageDummy';
+// import {
+//   FolderList,
+//   TagCategory,
+// } from '../../../pageComponents/folderlistComponents/components';
+// import styled from '@emotion/styled';
+// import { PAGE_URL } from '../../../constants/url.constants';
 
-const explore = () => {
-  const router = useRouter();
-  const { subTag } = router.query;
-  const label = `${subTag} 북마크 폴더 리스트 (${FolderListDummy.length})`;
-  return (
-    <Container>
-      <FolderList data={FolderListDummy} label={label}>
-        <TagCategory />
-      </FolderList>
-    </Container>
-  );
+export const getServerSideProps = async () => {
+  return {
+    redirect: {
+      destination: '/',
+    },
+  };
 };
 
-const Container = styled.div`
-  padding-top: 100px;
-`;
+const explore = () => {
+  // const router = useRouter();
+  // const { pathname, query, asPath } = router;
+  // const { mainTag, subTag } = query;
+  // router.push(
+  //   {
+  //     pathname: `${PAGE_URL.LIST}`,
+  //     query: {
+  //       mainTag,
+  //       subTag,
+  //     },
+  //   },
+  //   `${PAGE_URL.LIST}/explore/${subTag}`,
+  // );
+  return 'hello';
+  // const router = useRouter();
+  // const { subTag } = router.query;
+  // const label = `${subTag} 북마크 폴더 리스트 (${FolderListDummy.length})`;
+  // return (
+  //   <Container>
+  //     <FolderList data={FolderListDummy} label={label}>
+  //       <TagCategory />
+  //     </FolderList>
+  //   </Container>
+  // );
+};
+
+// const Container = styled.div`
+//   padding-top: 100px;
+// `;
 
 export default explore;

--- a/web/pages/folderlist/index.tsx
+++ b/web/pages/folderlist/index.tsx
@@ -1,0 +1,108 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { getFolderList, getTagFolder } from '../../apis/FolderAPI';
+import { Category, Pagination } from '../../components';
+import { TagCategory } from '../../pageComponents/folderlistComponents/components';
+import * as S from '../../styles/pageStyles/folderList.style';
+import { AllFolderList, TabType } from '../../types';
+
+const FolderList = () => {
+  const [data, setData] = useState([]);
+  const [totalElement, setTotalElment] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const [page, setPage] = useState(0);
+  const limit = 12;
+
+  const tabItems = [
+    { name: '최신순', value: 'createdAt,desc' },
+    { name: '오래된순', value: 'createdAt,asc' },
+    { name: '인기순', value: 'likes,desc' },
+    { name: '아이디순', value: 'id' },
+  ];
+  const [selectedItem, setSelectedItem] = useState(tabItems[0]);
+
+  const changeTabItem = (item: TabType) => {
+    setSelectedItem(item);
+  };
+
+  const router = useRouter();
+  const type = router.asPath.split('/')[2]; // search | explore
+  const { search, subTag } = router.query;
+
+  const label = () => {
+    if (type === 'explore') {
+      return `${subTag} 북마크 폴더 리스트 (${totalElement})`;
+    }
+    if (type === 'search') {
+      return `'${search}' 검색 결과(${totalElement})`;
+    }
+  };
+
+  useEffect(() => {
+    setIsLoading(true);
+    const fetch = async () => {
+      const size = 12;
+      const sort = selectedItem.value;
+      // 검색 필터링(혹은 전체 카테고리일 때)
+      // 나중에 API를 수정 요청
+      if (type === 'search' || subTag === '전체 카테고리') {
+        try {
+          const title: any = search || null;
+          const res: AllFolderList = await getFolderList(
+            { page, size, sort },
+            title,
+          );
+          setData(res.folders.content);
+          setTotalElment(res.folders.totalElements);
+          setIsLoading(false);
+        } catch {
+          throw new Error('API 요청중 에러 발생');
+        }
+        return;
+      }
+      // 태그 필터링
+      if (type === 'explore') {
+        try {
+          const res: AllFolderList = await getTagFolder(
+            { page, size, sort },
+            subTag.toString(),
+          );
+          setData(res.folders.content);
+          setTotalElment(res.folders.totalElements);
+          setIsLoading(false);
+        } catch {
+          throw new Error('API 요청중 에러 발생');
+        }
+      }
+    };
+    fetch();
+  }, [selectedItem, page, search, subTag]);
+
+  return (
+    <S.PageContainer>
+      {type === 'explore' && <TagCategory />}
+      <S.CategoryWrapper>
+        <S.DescriptionText>{label()}</S.DescriptionText>
+        <Category
+          data={data}
+          tabItems={tabItems}
+          isLoading={isLoading}
+          onClick={changeTabItem}
+          selectedItem={selectedItem}
+          cardVersion="othersCard"
+        />
+      </S.CategoryWrapper>
+      <S.PaginationWrapper>
+        <Pagination
+          defaultPage={0}
+          limit={limit}
+          total={totalElement}
+          onChange={setPage}
+        />
+      </S.PaginationWrapper>
+    </S.PageContainer>
+  );
+};
+
+export default FolderList;

--- a/web/pages/folderlist/search/[search].tsx
+++ b/web/pages/folderlist/search/[search].tsx
@@ -1,21 +1,30 @@
-import { useRouter } from 'next/router';
-import { FolderList } from '../../../pageComponents/folderlistComponents/components';
-import FolderListDummy from '../../../shared/folderListPageDummy';
-import styled from '@emotion/styled';
+// import { useRouter } from 'next/router';
+// import { FolderList } from '../../../pageComponents/folderlistComponents/components';
+// import FolderListDummy from '../../../shared/folderListPageDummy';
+// import styled from '@emotion/styled';
 
-const search = () => {
-  const router = useRouter();
-  const { search } = router.query;
-  const label = `'${search}' 검색 결과(${FolderListDummy.length})`;
-  return (
-    <Container>
-      <FolderList data={FolderListDummy} label={label} />
-    </Container>
-  );
+export const getServerSideProps = async () => {
+  return {
+    redirect: {
+      destination: '/',
+    },
+  };
 };
 
-const Container = styled.div`
-  padding-top: 200px;
-`;
+const search = () => {
+  return 'hello';
+  // const router = useRouter();
+  // const { search } = router.query;
+  // const label = `'${search}' 검색 결과(${FolderListDummy.length})`;
+  // return (
+  //   <Container>
+  //     <FolderList data={FolderListDummy} label={label} />
+  //   </Container>
+  // );
+};
+
+// const Container = styled.div`
+//   padding-top: 200px;
+// `;
 
 export default search;

--- a/web/pages/user/[id].tsx
+++ b/web/pages/user/[id].tsx
@@ -22,7 +22,7 @@ const UserPage = () => {
   const router = useRouter();
   const id = parseInt(router.query.id.toString());
   const getUserInfo: any = useRecoilValue(userInfo);
-  const userId = getUserInfo?.user?.id;
+  const loginUserId = getUserInfo?.user?.id;
 
   const [folderData, setFolderData] = useState([]);
   const [userData, setUserData] = useState<User>();
@@ -33,7 +33,7 @@ const UserPage = () => {
   const limit = 12;
 
   const tabItems =
-    id === userId
+    id === loginUserId
       ? [
           { name: '전체공개', value: 'public' },
           { name: '나만보기', value: 'private' },
@@ -159,7 +159,7 @@ const UserPage = () => {
       <S.PageContainer>
         <S.ProfileWrapper>
           {userData && <Profile user={userData} />}
-          {id === userId && (
+          {id === loginUserId && (
             <S.ProfileModifyBtn type="button" onClick={handleModal}>
               내 정보 수정
             </S.ProfileModifyBtn>
@@ -179,7 +179,7 @@ const UserPage = () => {
             isLoading={isLoading}
             onClick={changeTabItem}
             selectedItem={selectedItem}
-            cardVersion={id === userId ? 'myCard' : 'othersCard'}
+            cardVersion={id === loginUserId ? 'myCard' : 'othersCard'}
           />
         </S.CategoryWrapper>
         <S.PaginationWrapper>

--- a/web/styles/pageStyles/folderList.style.ts
+++ b/web/styles/pageStyles/folderList.style.ts
@@ -5,6 +5,7 @@ export const PageContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  padding-top: 170px;
 `;
 
 export const SearchBarWrapper = styled.div`

--- a/web/types/folder.ts
+++ b/web/types/folder.ts
@@ -15,8 +15,8 @@ interface Sort {
 export interface Folder {
   id: number;
   title: string;
-  content: string;
   image: string;
+  content: string;
   isPinned: boolean;
   isPrivate: boolean;
   user: User;
@@ -117,11 +117,12 @@ export interface GetFolderList {
   page: number;
   size: number;
   sort: string;
+  // title?: string;
 }
 
 export interface GetUserFolderList {
-  id: string;
-  isPrivate: boolean;
+  id: number;
+  isPrivate?: boolean;
   page: number;
   size: number;
   sort: string;

--- a/web/types/index.ts
+++ b/web/types/index.ts
@@ -13,3 +13,4 @@ export type {
 export type { Comments, CreateOrUpdateComment } from './comment';
 export type { CreateBookmark, Bookmark } from './bookmark';
 export type { TabType } from './tab';
+export type { TagType } from './tag';

--- a/web/types/tag.ts
+++ b/web/types/tag.ts
@@ -1,0 +1,8 @@
+export interface TagType {
+  tags: [
+    {
+      rootTag: string;
+      subTags: string[];
+    },
+  ];
+}


### PR DESCRIPTION
### 📌 설명

### 🎨 구현 내용
폴더리스트(탭, 태그), 유저페이지(탭) 필터링 기능
전체 태그 불러오는 API 

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->
폴더 리스트에서 한개의 페이지로 구현하는 대신 asPath를 사용해서 실제 url은 /folderlist이지만 보이는 url은 /folderlist/search/{value} 이런식 입니다. 
그런데 새로고침할 때 asPath를 실제 주소로 인식해서 404에러가 발생합니다. 따라서 임시로 해당 페이지에서 메인 페이지로 리다이렉트 하게 만들어놨습니다.

유저 페이지에서 탭으로 필터링 할 때 탭 개수만큼 api 개수를 요청해야 합니다. 간소화 할 수 있을까요?
### 🚀 연관된 이슈
Closes #111 