### PR TITLE
Feat: first login modal 로직 구현 + Comment 로직 수정

### DIFF
--- a/web/apis/UserAPI.ts
+++ b/web/apis/UserAPI.ts
@@ -40,16 +40,24 @@ export const getUserInfo = async (token: string) => {
 };
 
 // 내 정보 수정 성공
-export const updateUserInfo = async ({
-  name,
-  image,
-  interests,
-}: UpdateInfo) => {
-  const res = await axios.patch(`${USER}`, {
-    name,
-    image,
-    interests,
-  });
+export const updateUserInfo = async (
+  { name, image, introduce, interests }: UpdateInfo,
+  token: string,
+) => {
+  const res = await axios.patch(
+    `${USER}`,
+    {
+      name,
+      image,
+      introduce,
+      interests,
+    },
+    {
+      headers: {
+        'Access-Token': token,
+      },
+    },
+  );
 
   console.log(res);
   return res;

--- a/web/apis/UserAPI.ts
+++ b/web/apis/UserAPI.ts
@@ -8,7 +8,8 @@ export const userSignUp = async ({ email, password }: SignUpOrIn) => {
   const res = await axios.post(`${USER}${SIGNUP}`, {
     email,
     password,
-    image: 'https://avatars.githubusercontent.com/u/72294509?v=4',
+    image:
+      'https://linkbook-s3-1.s3-ap-northeast-2.amazonaws.com/static/userImage.png.png',
   });
 
   console.log(res);

--- a/web/components/Comment/Comment.tsx
+++ b/web/components/Comment/Comment.tsx
@@ -3,6 +3,9 @@ import { useState } from 'react';
 import { CommentInput } from '../index';
 import { Comment } from '../../types/comment';
 import CommentItem from './CommentItem';
+import { getCookie } from '../../util/cookies';
+import { useRecoilValue } from 'recoil';
+import { userInfo } from '../../recoil/user';
 
 interface Props {
   comment: Comment;
@@ -13,6 +16,8 @@ const CommentComponent = ({ comment, folderId }: Props) => {
   const [showReplies, setShowReplies] = useState(false);
   const [showInputArea, setShowInputArea] = useState(false);
   const { id, children } = comment;
+  const { user } = useRecoilValue(userInfo);
+  const token = getCookie('ACCESS_TOKEN');
 
   const handleShowReplies = () => {
     setShowReplies(!showReplies);
@@ -24,7 +29,12 @@ const CommentComponent = ({ comment, folderId }: Props) => {
 
   return (
     <S.Container key={id}>
-      <CommentItem comment={comment} folderId={folderId} />
+      <CommentItem
+        comment={comment}
+        folderId={folderId}
+        userId={user && user.id}
+        token={token}
+      />
       <S.ButtonContainer>
         <S.RepliesButton onClick={handleShowInputArea}>
           답글 달기 {showInputArea ? '-' : '+'}

--- a/web/components/Comment/CommentItem/CommentItem.tsx
+++ b/web/components/Comment/CommentItem/CommentItem.tsx
@@ -82,6 +82,7 @@ const CommentItem = ({ comment, folderId, userId, token }: Props) => {
           folderId={folderId}
           defaultValue={content}
           ref={updateInputRef}
+          placeholder="수정할 댓글을 입력해주세요."
         />
       ) : (
         <S.BodyWrapper>{content}</S.BodyWrapper>

--- a/web/components/Comment/CommentItem/CommentItem.tsx
+++ b/web/components/Comment/CommentItem/CommentItem.tsx
@@ -3,14 +3,15 @@ import { Comment, CreateOrUpdateComment } from '../../../types/comment';
 import { deleteComment, updateComment } from '../../../apis/CommentAPI';
 import { useRef, useState } from 'react';
 import { CommentInput, Profile } from '../../index';
-import { TEMP_TOKEN, TEMP_USER_ID } from '../../../constants/alert.constants';
 
 interface Props {
   comment: Comment;
   folderId: number;
+  userId?: number;
+  token?: string;
 }
 
-const CommentItem = ({ comment, folderId }: Props) => {
+const CommentItem = ({ comment, folderId, userId, token }: Props) => {
   const { id, content, user, createdAt } = comment;
   const [updating, setUpdating] = useState(false);
   const updateInputRef = useRef<HTMLTextAreaElement>(null);
@@ -26,14 +27,15 @@ const CommentItem = ({ comment, folderId }: Props) => {
       id,
       content: updateInputRef.current.value,
       folderId,
-      userId: TEMP_USER_ID,
+      userId,
     };
 
     try {
-      await updateComment(newComment, TEMP_TOKEN);
+      await updateComment(newComment, token);
       setUpdating(!updating);
     } catch (error) {
       console.log(error);
+      alert('문제가 발생했습니다.');
     }
   };
 
@@ -42,11 +44,13 @@ const CommentItem = ({ comment, folderId }: Props) => {
     if (!confirmDelete) return;
 
     try {
-      await deleteComment(id, TEMP_TOKEN);
+      await deleteComment(id, token);
     } catch (error) {
       console.log(error);
+      alert('문제가 발생했습니다.');
     }
   };
+
   return (
     <S.Container key={id}>
       <S.HeaderWrapper>
@@ -56,7 +60,7 @@ const CommentItem = ({ comment, folderId }: Props) => {
           createdAt={`${createdAt.slice(0, 10)} ${createdAt.slice(11, 19)}`}
           iconSize={50}
         />
-        {TEMP_USER_ID === user.id && (
+        {userId === user.id && (
           <>
             {updating ? (
               <S.ButtonsWrapper>
@@ -73,14 +77,12 @@ const CommentItem = ({ comment, folderId }: Props) => {
         )}
       </S.HeaderWrapper>
       {updating ? (
-        <>
-          <CommentInput
-            version="update"
-            folderId={folderId}
-            defaultValue={content}
-            ref={updateInputRef}
-          />
-        </>
+        <CommentInput
+          version="update"
+          folderId={folderId}
+          defaultValue={content}
+          ref={updateInputRef}
+        />
       ) : (
         <S.BodyWrapper>{content}</S.BodyWrapper>
       )}

--- a/web/components/CommentInput/CommentInput.tsx
+++ b/web/components/CommentInput/CommentInput.tsx
@@ -14,11 +14,18 @@ interface Props {
   folderId?: number;
   parentId?: number;
   defaultValue?: string;
+  placeholder?: string;
 }
 
 const CommentInput = forwardRef<HTMLTextAreaElement, Props>(
   (
-    { version = 'comment', folderId, parentId = null, defaultValue = '' },
+    {
+      version = 'comment',
+      folderId,
+      parentId = null,
+      defaultValue = '',
+      placeholder,
+    },
     ref,
   ) => {
     const [value, setValue] = useState(defaultValue);
@@ -36,6 +43,7 @@ const CommentInput = forwardRef<HTMLTextAreaElement, Props>(
       if (!user) {
         alert('로그인 후 이용해주세요.');
         setShowModal(showLoginModal);
+        return;
       }
 
       try {
@@ -61,7 +69,7 @@ const CommentInput = forwardRef<HTMLTextAreaElement, Props>(
       <S.Container>
         <S.InputContainer>
           <S.TextInput
-            placeholder={placeholderText}
+            placeholder={placeholder ? placeholder : placeholderText}
             ref={ref}
             onChange={handleChangeValue}
             defaultValue={value}

--- a/web/components/Modal/FirstLogin/FirstLogin.tsx
+++ b/web/components/Modal/FirstLogin/FirstLogin.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Page01, Page02, Page03, Page04, Page05 } from './FirstLoginPage';
 import { InnerContainer } from '../Modal.style';
+import UserInfoProvider from './contexts/UserInfoProvider';
 
 const FirstLogin = () => {
   const [page, setPage] = useState(0);
@@ -42,7 +43,11 @@ const FirstLogin = () => {
     }
   };
 
-  return <InnerContainer>{switchPage(page)}</InnerContainer>;
+  return (
+    <UserInfoProvider>
+      <InnerContainer>{switchPage(page)}</InnerContainer>
+    </UserInfoProvider>
+  );
 };
 
 export default FirstLogin;

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page01.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page01.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler, useRef, useState } from 'react';
+import { MouseEventHandler, useEffect, useRef, useState } from 'react';
 import * as S from '../../Modal.style';
 import { Input, Button } from '../../../index';
 import { useUserInfo } from '../contexts/UserInfoProvider';
@@ -10,7 +10,7 @@ interface Props {
 const Page01 = ({ handleNextPage }: Props) => {
   const nameRef = useRef<HTMLInputElement>(null);
   const [errorText, setErrorText] = useState('');
-  const { setUserName } = useUserInfo();
+  const { userInfo, setUserName } = useUserInfo();
 
   const handleClickStoreName: MouseEventHandler = (e) => {
     const nameValue = nameRef.current.value;
@@ -23,6 +23,10 @@ const Page01 = ({ handleNextPage }: Props) => {
 
     handleNextPage(e);
   };
+
+  useEffect(() => {
+    nameRef.current.value = userInfo.name;
+  }, [userInfo]);
 
   return (
     <>

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page01.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page01.tsx
@@ -1,12 +1,29 @@
-import { MouseEventHandler } from 'react';
+import { MouseEventHandler, useRef, useState } from 'react';
 import * as S from '../../Modal.style';
 import { Input, Button } from '../../../index';
+import { useUserInfo } from '../contexts/UserInfoProvider';
 
 interface Props {
   handleNextPage: MouseEventHandler;
 }
 
 const Page01 = ({ handleNextPage }: Props) => {
+  const nameRef = useRef<HTMLInputElement>(null);
+  const [errorText, setErrorText] = useState('');
+  const { setUserName } = useUserInfo();
+
+  const handleClickStoreName: MouseEventHandler = (e) => {
+    const nameValue = nameRef.current.value;
+    const res = setUserName(nameValue);
+
+    if (typeof res === 'string') {
+      setErrorText(res);
+      return;
+    }
+
+    handleNextPage(e);
+  };
+
   return (
     <>
       <S.Title>
@@ -15,9 +32,14 @@ const Page01 = ({ handleNextPage }: Props) => {
         <br />
         사용할 <S.MainText>닉네임</S.MainText>을 입력해 주세요.
       </S.Title>
-      <Input placeholder="닉네임" type="text" />
+      <Input
+        placeholder="닉네임"
+        type="text"
+        ref={nameRef}
+        errorText={errorText}
+      />
       <S.ButtonContainer>
-        <Button type="button" onClick={handleNextPage}>
+        <Button type="button" onClick={handleClickStoreName}>
           다음 &gt;
         </Button>
       </S.ButtonContainer>

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page02.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page02.tsx
@@ -1,6 +1,7 @@
-import { MouseEventHandler } from 'react';
+import { MouseEventHandler, useRef, useState } from 'react';
 import * as S from '../../Modal.style';
 import { Button, Input, Icon } from '../../../index';
+import { useUserInfo } from '../contexts/UserInfoProvider';
 
 interface Props {
   handleNextPage: MouseEventHandler;
@@ -8,6 +9,22 @@ interface Props {
 }
 
 const Page02 = ({ handleNextPage, handlePreviousPage }: Props) => {
+  const introduceRef = useRef<HTMLInputElement>(null);
+  const [errorText, setErrorText] = useState('');
+  const { setUserIntroduce } = useUserInfo();
+
+  const handleClickStoreIntroduce: MouseEventHandler = (e) => {
+    const introduceValue = introduceRef.current.value;
+    const res = setUserIntroduce(introduceValue);
+
+    if (typeof res === 'string') {
+      setErrorText(res);
+      return;
+    }
+
+    handleNextPage(e);
+  };
+
   return (
     <>
       <S.PreviousButton onClick={handlePreviousPage}>
@@ -19,9 +36,14 @@ const Page02 = ({ handleNextPage, handlePreviousPage }: Props) => {
         <br />
         <S.MainText>한 줄로 자신을 소개</S.MainText>해 주세요!
       </S.Title>
-      <Input placeholder="한 줄 소개" type="text" />
+      <Input
+        placeholder="한 줄 소개"
+        type="text"
+        ref={introduceRef}
+        errorText={errorText}
+      />
       <S.ButtonContainer>
-        <Button type="button" onClick={handleNextPage}>
+        <Button type="button" onClick={handleClickStoreIntroduce}>
           다음 &gt;
         </Button>
       </S.ButtonContainer>

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page02.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page02.tsx
@@ -11,7 +11,7 @@ interface Props {
 const Page02 = ({ handleNextPage, handlePreviousPage }: Props) => {
   const introduceRef = useRef<HTMLInputElement>(null);
   const [errorText, setErrorText] = useState('');
-  const { setUserIntroduce } = useUserInfo();
+  const { userInfo, setUserIntroduce } = useUserInfo();
 
   const handleClickStoreIntroduce: MouseEventHandler = (e) => {
     const introduceValue = introduceRef.current.value;
@@ -32,7 +32,7 @@ const Page02 = ({ handleNextPage, handlePreviousPage }: Props) => {
       </S.PreviousButton>
       <S.Title>
         <br />
-        Haeyum님 반가워요! 👋🏻
+        {userInfo.name}님 반가워요! 👋🏻
         <br />
         <S.MainText>한 줄로 자신을 소개</S.MainText>해 주세요!
       </S.Title>

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page02.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page02.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler, useRef, useState } from 'react';
+import { MouseEventHandler, useEffect, useRef, useState } from 'react';
 import * as S from '../../Modal.style';
 import { Button, Input, Icon } from '../../../index';
 import { useUserInfo } from '../contexts/UserInfoProvider';
@@ -24,6 +24,10 @@ const Page02 = ({ handleNextPage, handlePreviousPage }: Props) => {
 
     handleNextPage(e);
   };
+
+  useEffect(() => {
+    introduceRef.current.value = userInfo.introduce;
+  }, [userInfo]);
 
   return (
     <>

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page03.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page03.tsx
@@ -1,5 +1,5 @@
 import * as S from '../../Modal.style';
-import { MouseEventHandler, useState } from 'react';
+import { MouseEventHandler, useEffect, useState } from 'react';
 import { Button, Icon, TagSelector } from '../../../index';
 import { useUserInfo } from '../contexts/UserInfoProvider';
 
@@ -9,13 +9,17 @@ interface Props {
 }
 
 const Page03 = ({ handleNextPage, handlePreviousPage }: Props) => {
-  const { setUserInterests } = useUserInfo();
+  const { userInfo, setUserInterests } = useUserInfo();
   const [selectedTag, setSelectedTag] = useState([]);
 
   const handleClickStoreInterests: MouseEventHandler = (e) => {
     setUserInterests(selectedTag);
     handleNextPage(e);
   };
+
+  useEffect(() => {
+    setSelectedTag(userInfo.interests);
+  }, [userInfo]);
 
   return (
     <>

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page03.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page03.tsx
@@ -1,6 +1,6 @@
-import { MouseEventHandler } from 'react';
+import { MouseEventHandler, useState } from 'react';
 import * as S from '../../Modal.style';
-import { Button, Input, Icon } from '../../../index';
+import { Button, Input, Icon, TagSelector } from '../../../index';
 
 interface Props {
   handleNextPage: MouseEventHandler;
@@ -8,6 +8,7 @@ interface Props {
 }
 
 const Page03 = ({ handleNextPage, handlePreviousPage }: Props) => {
+  const [selectedTag, setSelectedTag] = useState([]);
   return (
     <>
       <S.PreviousButton onClick={handlePreviousPage}>
@@ -21,7 +22,7 @@ const Page03 = ({ handleNextPage, handlePreviousPage }: Props) => {
           추천해드려요.
         </S.Description>
       </S.Title>
-      <Input placeholder="관심사를 선택해주세요." type="text" />
+      <TagSelector selectedTag={selectedTag} setSelectedTag={setSelectedTag} />
       <S.ButtonContainer>
         <Button type="button" onClick={handleNextPage}>
           다음 &gt;

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page03.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page03.tsx
@@ -1,6 +1,7 @@
-import { MouseEventHandler, useState } from 'react';
 import * as S from '../../Modal.style';
-import { Button, Input, Icon, TagSelector } from '../../../index';
+import { MouseEventHandler, useState } from 'react';
+import { Button, Icon, TagSelector } from '../../../index';
+import { useUserInfo } from '../contexts/UserInfoProvider';
 
 interface Props {
   handleNextPage: MouseEventHandler;
@@ -8,7 +9,14 @@ interface Props {
 }
 
 const Page03 = ({ handleNextPage, handlePreviousPage }: Props) => {
+  const { setUserInterests } = useUserInfo();
   const [selectedTag, setSelectedTag] = useState([]);
+
+  const handleClickStoreInterests: MouseEventHandler = (e) => {
+    setUserInterests(selectedTag);
+    handleNextPage(e);
+  };
+
   return (
     <>
       <S.PreviousButton onClick={handlePreviousPage}>
@@ -22,9 +30,14 @@ const Page03 = ({ handleNextPage, handlePreviousPage }: Props) => {
           추천해드려요.
         </S.Description>
       </S.Title>
-      <TagSelector selectedTag={selectedTag} setSelectedTag={setSelectedTag} />
+      <S.TagSelectorWrapper>
+        <TagSelector
+          selectedTag={selectedTag}
+          setSelectedTag={setSelectedTag}
+        />
+      </S.TagSelectorWrapper>
       <S.ButtonContainer>
-        <Button type="button" onClick={handleNextPage}>
+        <Button type="button" onClick={handleClickStoreInterests}>
           다음 &gt;
         </Button>
       </S.ButtonContainer>

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page04.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page04.tsx
@@ -1,6 +1,6 @@
 import { MouseEventHandler } from 'react';
 import * as S from '../../Modal.style';
-import { Button, Input, Icon } from '../../../index';
+import { Button, ImageUpload, Icon } from '../../../index';
 
 interface Props {
   handleNextPage: MouseEventHandler;
@@ -21,7 +21,9 @@ const Page02 = ({ handleNextPage, handlePreviousPage }: Props) => {
           <S.MainText>'마이페이지'</S.MainText>에서 얼마든지 변경할 수 있어요!
         </S.Description>
       </S.Title>
-      <S.IconContainer>{/* 사용자의 프로필 사진 */}</S.IconContainer>
+      <S.IconContainer>
+        <ImageUpload version="modal" />
+      </S.IconContainer>
       <S.ButtonContainer>
         <Button type="button" onClick={handleNextPage}>
           다음 &gt;

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page04.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page04.tsx
@@ -1,7 +1,9 @@
-import { MouseEventHandler, useState } from 'react';
 import * as S from '../../Modal.style';
+import { MouseEventHandler, useState } from 'react';
 import { Button, ImageUpload, Icon } from '../../../index';
 import { useUserInfo } from '../contexts/UserInfoProvider';
+import { updateUserInfo } from '../../../../apis/UserAPI';
+import { getCookie } from '../../../../util/cookies';
 
 interface Props {
   handleNextPage: MouseEventHandler;
@@ -11,14 +13,23 @@ interface Props {
 const Page04 = ({ handleNextPage, handlePreviousPage }: Props) => {
   const [imageSrc, setImageSrc] = useState('');
   const [errorText, setErrorText] = useState('');
-  const { setUserImage } = useUserInfo();
+  const { userInfo, setUserImage, removeUserInfo } = useUserInfo();
+  const token = getCookie('ACCESS_TOKEN');
 
-  const handleClickStoreImage: MouseEventHandler = (e) => {
-    const res = setUserImage(imageSrc);
+  const handleClickStoreImage: MouseEventHandler = async (e) => {
+    const setImageResult = setUserImage(imageSrc);
 
-    if (typeof res === 'string') {
-      setErrorText(res);
+    if (typeof setImageResult === 'string') {
+      setErrorText(setImageResult);
       return;
+    }
+
+    try {
+      await updateUserInfo(userInfo, token);
+      await removeUserInfo();
+    } catch (error) {
+      console.log(error);
+      alert('문제가 발생했습니다.');
     }
 
     handleNextPage(e);
@@ -30,7 +41,7 @@ const Page04 = ({ handleNextPage, handlePreviousPage }: Props) => {
         <Icon name="arrowLeft" size={30} />
       </S.PreviousButton>
       <S.Title>
-        Haeyum님만의
+        {userInfo.name}님만의
         <br />
         <S.MainText>프로필 사진</S.MainText>을 설정해 주세요!
         <S.Description>

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page04.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page04.tsx
@@ -2,8 +2,10 @@ import * as S from '../../Modal.style';
 import { MouseEventHandler, useState } from 'react';
 import { Button, ImageUpload, Icon } from '../../../index';
 import { useUserInfo } from '../contexts/UserInfoProvider';
-import { updateUserInfo } from '../../../../apis/UserAPI';
+import { getUserInfo, updateUserInfo } from '../../../../apis/UserAPI';
 import { getCookie } from '../../../../util/cookies';
+import { useSetRecoilState } from 'recoil';
+import { userInfo as userInfoRecoil } from '../../../../recoil/user';
 
 interface Props {
   handleNextPage: MouseEventHandler;
@@ -13,20 +15,24 @@ interface Props {
 const Page04 = ({ handleNextPage, handlePreviousPage }: Props) => {
   const [imageSrc, setImageSrc] = useState('');
   const [errorText, setErrorText] = useState('');
-  const { userInfo, setUserImage, removeUserInfo } = useUserInfo();
+  const { userInfo, getUpdatedUserInfo, removeUserInfo } = useUserInfo();
+  const setUserInfoState = useSetRecoilState(userInfoRecoil);
   const token = getCookie('ACCESS_TOKEN');
 
   const handleClickStoreImage: MouseEventHandler = async (e) => {
-    const setImageResult = setUserImage(imageSrc);
+    const updatedUserInfo = getUpdatedUserInfo(imageSrc);
 
-    if (typeof setImageResult === 'string') {
-      setErrorText(setImageResult);
+    if (typeof updatedUserInfo === 'string') {
+      setErrorText(updatedUserInfo);
       return;
     }
 
     try {
-      await updateUserInfo(userInfo, token);
+      await updateUserInfo(updatedUserInfo, token);
       await removeUserInfo();
+
+      const newUserInfo = await getUserInfo(token);
+      setUserInfoState(newUserInfo);
     } catch (error) {
       console.log(error);
       alert('문제가 발생했습니다.');

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page04.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page04.tsx
@@ -1,13 +1,29 @@
-import { MouseEventHandler } from 'react';
+import { MouseEventHandler, useState } from 'react';
 import * as S from '../../Modal.style';
 import { Button, ImageUpload, Icon } from '../../../index';
+import { useUserInfo } from '../contexts/UserInfoProvider';
 
 interface Props {
   handleNextPage: MouseEventHandler;
   handlePreviousPage: MouseEventHandler;
 }
 
-const Page02 = ({ handleNextPage, handlePreviousPage }: Props) => {
+const Page04 = ({ handleNextPage, handlePreviousPage }: Props) => {
+  const [imageSrc, setImageSrc] = useState('');
+  const [errorText, setErrorText] = useState('');
+  const { setUserImage } = useUserInfo();
+
+  const handleClickStoreImage: MouseEventHandler = (e) => {
+    const res = setUserImage(imageSrc);
+
+    if (typeof res === 'string') {
+      setErrorText(res);
+      return;
+    }
+
+    handleNextPage(e);
+  };
+
   return (
     <>
       <S.PreviousButton onClick={handlePreviousPage}>
@@ -22,10 +38,11 @@ const Page02 = ({ handleNextPage, handlePreviousPage }: Props) => {
         </S.Description>
       </S.Title>
       <S.IconContainer>
-        <ImageUpload version="modal" />
+        <ImageUpload version="modal" setImageSrc={setImageSrc} />
+        <S.ErrorText>{errorText}</S.ErrorText>
       </S.IconContainer>
       <S.ButtonContainer>
-        <Button type="button" onClick={handleNextPage}>
+        <Button type="button" onClick={handleClickStoreImage}>
           다음 &gt;
         </Button>
       </S.ButtonContainer>
@@ -33,4 +50,4 @@ const Page02 = ({ handleNextPage, handlePreviousPage }: Props) => {
   );
 };
 
-export default Page02;
+export default Page04;

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page04.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page04.tsx
@@ -1,5 +1,5 @@
 import * as S from '../../Modal.style';
-import { MouseEventHandler, useState } from 'react';
+import { MouseEventHandler, useEffect, useState } from 'react';
 import { Button, ImageUpload, Icon } from '../../../index';
 import { useUserInfo } from '../contexts/UserInfoProvider';
 import { getUserInfo, updateUserInfo } from '../../../../apis/UserAPI';
@@ -40,6 +40,10 @@ const Page04 = ({ handleNextPage, handlePreviousPage }: Props) => {
 
     handleNextPage(e);
   };
+
+  useEffect(() => {
+    setImageSrc(userInfo.image);
+  }, [userInfo]);
 
   return (
     <>

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page05.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page05.tsx
@@ -2,12 +2,13 @@ import { MouseEventHandler } from 'react';
 import * as S from '../../Modal.style';
 import { Icon } from '../../../index';
 import Link from 'next/link';
+import { PAGE_URL } from '../../../../constants/url.constants';
 
 interface Props {
   handlePreviousPage: MouseEventHandler;
 }
 
-const Page02 = ({ handlePreviousPage }: Props) => {
+const Page05 = ({ handlePreviousPage }: Props) => {
   return (
     <>
       <S.PreviousButton onClick={handlePreviousPage}>
@@ -22,7 +23,7 @@ const Page02 = ({ handlePreviousPage }: Props) => {
         <S.MainText>북마크 폴더</S.MainText>를 등록하러 가 볼까요?
       </S.Title>
       <S.ButtonContainer>
-        <Link href="/information" passHref>
+        <Link href={PAGE_URL.INFO} passHref>
           <S.ConfirmButton type="button">
             <S.LogoText>링북</S.LogoText> 100% 활용법 &gt;
           </S.ConfirmButton>
@@ -32,4 +33,4 @@ const Page02 = ({ handlePreviousPage }: Props) => {
   );
 };
 
-export default Page02;
+export default Page05;

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page05.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page05.tsx
@@ -1,7 +1,7 @@
-import { MouseEventHandler } from 'react';
 import * as S from '../../Modal.style';
-import { Icon } from '../../../index';
 import Link from 'next/link';
+import { MouseEventHandler } from 'react';
+import { Icon } from '../../../index';
 import { PAGE_URL } from '../../../../constants/url.constants';
 
 interface Props {

--- a/web/components/Modal/FirstLogin/contexts/UserInfoProvider.tsx
+++ b/web/components/Modal/FirstLogin/contexts/UserInfoProvider.tsx
@@ -1,0 +1,73 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import { UpdateInfo } from '../../../../types';
+
+interface IUserInfoContext {
+  userInfo: UpdateInfo;
+  setUserName: Function;
+  setUserIntroduce: Function;
+  setUserInfo: Function;
+  removeUserInfo: Function;
+}
+
+const UserInfoContext = createContext<IUserInfoContext>(null);
+export const useUserInfo = () => useContext(UserInfoContext);
+
+const UserInfoProvider = ({ children }: any) => {
+  const defaultValue: UpdateInfo = {
+    name: '',
+    introduce: '',
+    interests: [],
+    image: '',
+  };
+  const [userInfo, setUserInfo] = useState(defaultValue);
+
+  const setUserName = (nameValue: string) => {
+    const nameLen = nameValue.length;
+    if (nameLen > 8 || nameLen === 0)
+      return '1-8자 사이의 길이로 입력해주세요.';
+
+    setUserInfo({
+      ...userInfo,
+      name: nameValue,
+    });
+
+    return true;
+  };
+
+  const setUserIntroduce = (introduceValue: string) => {
+    const introduceLen = introduceValue.length;
+    if (introduceLen > 50 || introduceLen === 0)
+      return '1-50자 사이의 길이로 입력해주세요.';
+
+    setUserInfo({
+      ...userInfo,
+      introduce: introduceValue,
+    });
+
+    return true;
+  };
+
+  const removeUserInfo = () => {
+    setUserInfo(defaultValue);
+  };
+
+  useEffect(() => {
+    console.log(userInfo);
+  }, [userInfo]);
+
+  return (
+    <UserInfoContext.Provider
+      value={{
+        userInfo,
+        setUserInfo,
+        setUserName,
+        setUserIntroduce,
+        removeUserInfo,
+      }}
+    >
+      {children}
+    </UserInfoContext.Provider>
+  );
+};
+
+export default UserInfoProvider;

--- a/web/components/Modal/FirstLogin/contexts/UserInfoProvider.tsx
+++ b/web/components/Modal/FirstLogin/contexts/UserInfoProvider.tsx
@@ -6,7 +6,7 @@ interface IUserInfoContext {
   setUserName: Function;
   setUserIntroduce: Function;
   setUserInterests: Function;
-  setUserImage: Function;
+  getUpdatedUserInfo: Function;
   setUserInfo: Function;
   removeUserInfo: Function;
 }
@@ -58,16 +58,14 @@ const UserInfoProvider = ({ children }: any) => {
     return true;
   };
 
-  const setUserImage = (imageSrc: string) => {
+  const getUpdatedUserInfo = (imageSrc: string) => {
     const imageLen = imageSrc.length;
     if (imageLen === 0) return '이미지를 업로드해주세요.';
 
-    setUserInfo({
+    return {
       ...userInfo,
       image: imageSrc,
-    });
-
-    return true;
+    };
   };
 
   const removeUserInfo = () => {
@@ -86,7 +84,7 @@ const UserInfoProvider = ({ children }: any) => {
         setUserName,
         setUserIntroduce,
         setUserInterests,
-        setUserImage,
+        getUpdatedUserInfo,
         removeUserInfo,
       }}
     >

--- a/web/components/Modal/FirstLogin/contexts/UserInfoProvider.tsx
+++ b/web/components/Modal/FirstLogin/contexts/UserInfoProvider.tsx
@@ -5,6 +5,7 @@ interface IUserInfoContext {
   userInfo: UpdateInfo;
   setUserName: Function;
   setUserIntroduce: Function;
+  setUserInterests: Function;
   setUserImage: Function;
   setUserInfo: Function;
   removeUserInfo: Function;
@@ -48,6 +49,15 @@ const UserInfoProvider = ({ children }: any) => {
     return true;
   };
 
+  const setUserInterests = (tags: string[]) => {
+    setUserInfo({
+      ...userInfo,
+      interests: tags,
+    });
+
+    return true;
+  };
+
   const setUserImage = (imageSrc: string) => {
     const imageLen = imageSrc.length;
     if (imageLen === 0) return '이미지를 업로드해주세요.';
@@ -75,6 +85,7 @@ const UserInfoProvider = ({ children }: any) => {
         setUserInfo,
         setUserName,
         setUserIntroduce,
+        setUserInterests,
         setUserImage,
         removeUserInfo,
       }}

--- a/web/components/Modal/FirstLogin/contexts/UserInfoProvider.tsx
+++ b/web/components/Modal/FirstLogin/contexts/UserInfoProvider.tsx
@@ -5,6 +5,7 @@ interface IUserInfoContext {
   userInfo: UpdateInfo;
   setUserName: Function;
   setUserIntroduce: Function;
+  setUserImage: Function;
   setUserInfo: Function;
   removeUserInfo: Function;
 }
@@ -47,6 +48,18 @@ const UserInfoProvider = ({ children }: any) => {
     return true;
   };
 
+  const setUserImage = (imageSrc: string) => {
+    const imageLen = imageSrc.length;
+    if (imageLen === 0) return '이미지를 업로드해주세요.';
+
+    setUserInfo({
+      ...userInfo,
+      image: imageSrc,
+    });
+
+    return true;
+  };
+
   const removeUserInfo = () => {
     setUserInfo(defaultValue);
   };
@@ -62,6 +75,7 @@ const UserInfoProvider = ({ children }: any) => {
         setUserInfo,
         setUserName,
         setUserIntroduce,
+        setUserImage,
         removeUserInfo,
       }}
     >

--- a/web/components/Modal/FirstLogin/contexts/UserInfoProvider.tsx
+++ b/web/components/Modal/FirstLogin/contexts/UserInfoProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState } from 'react';
+import { createContext, useContext, useState } from 'react';
 import { UpdateInfo } from '../../../../types';
 
 interface IUserInfoContext {
@@ -62,19 +62,18 @@ const UserInfoProvider = ({ children }: any) => {
     const imageLen = imageSrc.length;
     if (imageLen === 0) return '이미지를 업로드해주세요.';
 
-    return {
+    const finalUserInfo = {
       ...userInfo,
       image: imageSrc,
     };
+
+    setUserInfo(finalUserInfo);
+    return finalUserInfo;
   };
 
   const removeUserInfo = () => {
     setUserInfo(defaultValue);
   };
-
-  useEffect(() => {
-    console.log(userInfo);
-  }, [userInfo]);
 
   return (
     <UserInfoContext.Provider

--- a/web/components/Modal/Login/Login.tsx
+++ b/web/components/Modal/Login/Login.tsx
@@ -61,7 +61,7 @@ const Login = () => {
   }, []);
 
   return (
-    <S.InnerContainer onSubmit={handleSubmit(onSubmit)}>
+    <S.FormContainer onSubmit={handleSubmit(onSubmit)}>
       <S.Title>
         <S.MainText>Linkbook</S.MainText>에 오신것을 환영합니다! 🎉
       </S.Title>
@@ -105,7 +105,7 @@ const Login = () => {
           </Button>
         </S.ButtonContainer>
       </S.SignUpContainer>
-    </S.InnerContainer>
+    </S.FormContainer>
   );
 };
 

--- a/web/components/Modal/Modal.style.ts
+++ b/web/components/Modal/Modal.style.ts
@@ -115,8 +115,8 @@ export const MainText = styled.span`
 `;
 
 export const IconContainer = styled.div`
-  width: 150px;
-  height: 150px;
+  width: fit-content;
+  height: fit-content;
   margin: 0 auto;
   overflow: hidden;
   border: ${({ theme }) => `1px solid ${theme.colors.gray[4]}`};

--- a/web/components/Modal/Modal.style.ts
+++ b/web/components/Modal/Modal.style.ts
@@ -198,3 +198,7 @@ export const ErrorText = styled.p`
   color: red;
   margin: 5px;
 `;
+
+export const TagSelectorWrapper = styled.div`
+  height: 200px;
+`;

--- a/web/components/Modal/Modal.style.ts
+++ b/web/components/Modal/Modal.style.ts
@@ -73,7 +73,16 @@ export const CloseBtn = styled.button`
 `;
 
 // Modal Inner(version) Style
-export const InnerContainer = styled.form`
+export const FormContainer = styled.form`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  width: 420px;
+  height: 420px;
+  margin: 30px auto;
+`;
+
+export const InnerContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/web/components/Modal/Modal.style.ts
+++ b/web/components/Modal/Modal.style.ts
@@ -119,8 +119,7 @@ export const IconContainer = styled.div`
   height: fit-content;
   margin: 0 auto;
   overflow: hidden;
-  border: ${({ theme }) => `1px solid ${theme.colors.gray[4]}`};
-  border-radius: 300px;
+  text-align: center;
 `;
 
 export const InputContainer = styled.div`
@@ -192,4 +191,10 @@ export const ConfirmButton = styled.button`
 export const LogoText = styled.span`
   font-size: ${({ theme }) => theme.fontSize.l[2]};
   font-family: 'Dongle', sans-serif;
+`;
+
+export const ErrorText = styled.p`
+  font-size: ${({ theme }) => theme.fontSize.c[0]};
+  color: red;
+  margin: 5px;
 `;

--- a/web/components/Modal/SignUp/SignUpPage/Page01.tsx
+++ b/web/components/Modal/SignUp/SignUpPage/Page01.tsx
@@ -49,7 +49,7 @@ const Page01 = ({ handlePage }: Props) => {
   };
 
   return (
-    <S.InnerContainer onSubmit={handleSubmit(onSubmit)}>
+    <S.FormContainer onSubmit={handleSubmit(onSubmit)}>
       <S.Title>
         <S.MainText>Linkbook</S.MainText>에 처음 오셨군요! 🎉
         <br />
@@ -85,7 +85,7 @@ const Page01 = ({ handlePage }: Props) => {
           다음 &gt;
         </Button>
       </S.ButtonContainer>
-    </S.InnerContainer>
+    </S.FormContainer>
   );
 };
 

--- a/web/components/Modal/SignUp/SignUpPage/Page02.tsx
+++ b/web/components/Modal/SignUp/SignUpPage/Page02.tsx
@@ -53,7 +53,7 @@ const Page02 = ({ handlePage }: Props) => {
   }, []);
 
   return (
-    <S.InnerContainer onSubmit={handleSubmit(onSubmit)}>
+    <S.FormContainer onSubmit={handleSubmit(onSubmit)}>
       <S.PreviousButton onClick={handlePage}>
         <Icon name="arrowLeft" size={30} />
       </S.PreviousButton>
@@ -84,7 +84,7 @@ const Page02 = ({ handlePage }: Props) => {
       <S.ButtonContainer>
         <Button type="submit">회원가입 &gt;</Button>
       </S.ButtonContainer>
-    </S.InnerContainer>
+    </S.FormContainer>
   );
 };
 

--- a/web/components/NavigationBar/LoginSection/LoginSection.tsx
+++ b/web/components/NavigationBar/LoginSection/LoginSection.tsx
@@ -7,9 +7,11 @@ import { removeCookie } from '../../../util/cookies';
 import { loginStatus } from '../../../recoil/authentication';
 import { useSetRecoilState } from 'recoil';
 import { useRouter } from 'next/router';
+import { userInfo } from '../../../recoil/user';
 
 const LoginSection = () => {
   const setLoginState = useSetRecoilState(loginStatus);
+  const setUserInfo = useSetRecoilState(userInfo);
   const router = useRouter();
 
   const handleCreateFolder = () => {
@@ -20,6 +22,7 @@ const LoginSection = () => {
     removeCookie('ACCESS_TOKEN');
     removeCookie('REFRESH_TOKEN');
     setLoginState(false);
+    setUserInfo({});
   };
 
   return (

--- a/web/components/NavigationBar/LoginSection/LoginSection.tsx
+++ b/web/components/NavigationBar/LoginSection/LoginSection.tsx
@@ -40,9 +40,11 @@ const LoginSection = () => {
       <Avatar size={35} src={avatarSrc} />
       <S.Line>|</S.Line>
       <S.UserContainer>
-        <Link href={`${PAGE_URL.USER}/${userInfoValue.user.id}`} passHref>
-          <S.NavItem>마이페이지</S.NavItem>
-        </Link>
+        {userInfoValue.user && (
+          <Link href={`${PAGE_URL.USER}/${userInfoValue.user.id}`} passHref>
+            <S.NavItem>마이페이지</S.NavItem>
+          </Link>
+        )}
         <Button type="button" version="navBar" onClick={handleCreateFolder}>
           새 폴더 작성
         </Button>

--- a/web/components/NavigationBar/LoginSection/LoginSection.tsx
+++ b/web/components/NavigationBar/LoginSection/LoginSection.tsx
@@ -1,18 +1,20 @@
 import * as S from '../NavigationBar.style';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import { Avatar, Button } from '../../index';
 import { PAGE_URL } from '../../../constants/url.constants';
 import { TEMP_USER_ID } from '../../../constants/alert.constants';
 import { removeCookie } from '../../../util/cookies';
 import { loginStatus } from '../../../recoil/authentication';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
 import { useRouter } from 'next/router';
 import { userInfo } from '../../../recoil/user';
 
 const LoginSection = () => {
   const setLoginState = useSetRecoilState(loginStatus);
-  const [userInfoValue, setUserInfoValue] = useRecoilState(userInfo);
-  console.log(userInfoValue);
+  const userInfoValue = useRecoilValue(userInfo);
+  const resetUserInfoValue = useResetRecoilState(userInfo);
+  const [avatarSrc, setAvatarSrc] = useState(undefined);
   const router = useRouter();
 
   const handleCreateFolder = () => {
@@ -23,13 +25,20 @@ const LoginSection = () => {
     removeCookie('ACCESS_TOKEN');
     removeCookie('REFRESH_TOKEN');
     setLoginState(false);
-    setUserInfoValue({});
+    resetUserInfoValue();
   };
+
+  useEffect(() => {
+    if (!userInfoValue.user) return;
+
+    const { user } = userInfoValue;
+    setAvatarSrc(user.image);
+  }, [userInfoValue]);
 
   return (
     <>
       <S.Line>|</S.Line>
-      <Avatar size={35} />
+      <Avatar size={35} src={avatarSrc} />
       <S.Line>|</S.Line>
       <S.UserContainer>
         <Link href={`${PAGE_URL.USER}/${TEMP_USER_ID}`} passHref>

--- a/web/components/NavigationBar/LoginSection/LoginSection.tsx
+++ b/web/components/NavigationBar/LoginSection/LoginSection.tsx
@@ -24,6 +24,7 @@ const LoginSection = () => {
 
   return (
     <>
+      <S.Line>|</S.Line>
       <Avatar size={35} />
       <S.Line>|</S.Line>
       <S.UserContainer>

--- a/web/components/NavigationBar/LoginSection/LoginSection.tsx
+++ b/web/components/NavigationBar/LoginSection/LoginSection.tsx
@@ -5,13 +5,14 @@ import { PAGE_URL } from '../../../constants/url.constants';
 import { TEMP_USER_ID } from '../../../constants/alert.constants';
 import { removeCookie } from '../../../util/cookies';
 import { loginStatus } from '../../../recoil/authentication';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import { useRouter } from 'next/router';
 import { userInfo } from '../../../recoil/user';
 
 const LoginSection = () => {
   const setLoginState = useSetRecoilState(loginStatus);
-  const setUserInfo = useSetRecoilState(userInfo);
+  const [userInfoValue, setUserInfoValue] = useRecoilState(userInfo);
+  console.log(userInfoValue);
   const router = useRouter();
 
   const handleCreateFolder = () => {
@@ -22,7 +23,7 @@ const LoginSection = () => {
     removeCookie('ACCESS_TOKEN');
     removeCookie('REFRESH_TOKEN');
     setLoginState(false);
-    setUserInfo({});
+    setUserInfoValue({});
   };
 
   return (

--- a/web/components/NavigationBar/LoginSection/LoginSection.tsx
+++ b/web/components/NavigationBar/LoginSection/LoginSection.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { Avatar, Button } from '../../index';
 import { PAGE_URL } from '../../../constants/url.constants';
-import { TEMP_USER_ID } from '../../../constants/alert.constants';
 import { removeCookie } from '../../../util/cookies';
 import { loginStatus } from '../../../recoil/authentication';
 import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
@@ -41,7 +40,7 @@ const LoginSection = () => {
       <Avatar size={35} src={avatarSrc} />
       <S.Line>|</S.Line>
       <S.UserContainer>
-        <Link href={`${PAGE_URL.USER}/${TEMP_USER_ID}`} passHref>
+        <Link href={`${PAGE_URL.USER}/${userInfoValue.user.id}`} passHref>
           <S.NavItem>마이페이지</S.NavItem>
         </Link>
         <Button type="button" version="navBar" onClick={handleCreateFolder}>

--- a/web/components/NavigationBar/NavigationBar.style.ts
+++ b/web/components/NavigationBar/NavigationBar.style.ts
@@ -71,5 +71,14 @@ export const UserButton = styled.button`
 `;
 
 export const IconWrapper = styled.div`
+  width: 32px;
+  height: 32px;
+  padding-top: 6px;
+  text-align: center;
+  border-radius: 50%;
   cursor: pointer;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.gray[5]};
+  }
 `;

--- a/web/components/NavigationBar/NavigationBar.tsx
+++ b/web/components/NavigationBar/NavigationBar.tsx
@@ -2,8 +2,8 @@ import * as S from './NavigationBar.style';
 import Link from 'next/link';
 import nookies from 'nookies';
 import { useEffect, useState } from 'react';
-import { Avatar, Button, Icon, Text, Modal, SearchBar } from '../index';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { Icon, Text, SearchBar } from '../index';
+import { useRecoilValue } from 'recoil';
 import { loginStatus } from '../../recoil/authentication';
 import { NextPageContext } from 'next';
 import { PAGE_URL } from '../../constants/url.constants';
@@ -52,13 +52,13 @@ const NavigationBar = ({ token }: Props) => {
           <S.Nav>
             <Link
               href={{
-                pathname: '/folderlist/explore/all',
+                pathname: `${PAGE_URL.LIST}/explore/all`,
                 query: {
                   mainTag: 'all',
                   subTag: 'all',
                 },
               }}
-              as={'/folderlist/explore/all'}
+              as={`${PAGE_URL.LIST}/explore/all`}
               passHref
             >
               <S.NavItem>북마크리스트</S.NavItem>
@@ -68,9 +68,8 @@ const NavigationBar = ({ token }: Props) => {
             </Link>
           </S.Nav>
           <S.IconWrapper onClick={handleClickSearch}>
-            <Icon name="search_ic" size={20} />
+            <Icon name="search_ic" size={18} />
           </S.IconWrapper>
-          <S.Line>|</S.Line>
           {isLoggedIn ? <LoginSection /> : <LogoutSection />}
         </S.ItemContainer>
         {showSearchBar && <SearchBar setShowSearchBar={setShowSearchBar} />}

--- a/web/components/TagSelector/TagSelector.tsx
+++ b/web/components/TagSelector/TagSelector.tsx
@@ -27,20 +27,17 @@ const TagSelector = ({ selectedTag, setSelectedTag, ...styles }: Props) => {
   const listRef = useRef<HTMLUListElement>(null);
 
   const [activeItem, setActiveItem] = useState(0);
-  const [autoCompleteSearch, setAutoCompleteSearch] = useState<string[]>([]);
-  const [inputResultVisible, setInputResultVisible] = useState(false);
+  const [autoCompleteSearch, setAutoCompleteSearch] = useState<string[]>(tags);
 
   const handleFilterInputValue = () => {
-    const keyword = inputRef.current!.value;
+    const keyword = inputRef.current.value;
     const filteredSearch = tags.filter((tag) => tag.indexOf(keyword) >= 0);
 
     if (!keyword) {
-      setAutoCompleteSearch([]);
-      handleVisibleInputResult(false);
+      setAutoCompleteSearch(tags);
       return;
     }
 
-    handleVisibleInputResult(true);
     setAutoCompleteSearch(filteredSearch);
   };
 
@@ -52,8 +49,7 @@ const TagSelector = ({ selectedTag, setSelectedTag, ...styles }: Props) => {
   };
 
   const handleResetSelector = () => {
-    inputRef.current!.value = '';
-    handleVisibleInputResult(false);
+    inputRef.current.value = '';
     setActiveItem(0);
   };
 
@@ -67,12 +63,8 @@ const TagSelector = ({ selectedTag, setSelectedTag, ...styles }: Props) => {
     setSelectedTag(updatedData);
   };
 
-  const handleVisibleInputResult = (state: boolean) => {
-    setInputResultVisible(state);
-  };
-
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (!inputResultVisible || e.keyCode === 229) {
+    if (e.keyCode === 229) {
       return;
     }
 
@@ -83,13 +75,13 @@ const TagSelector = ({ selectedTag, setSelectedTag, ...styles }: Props) => {
       case 'ArrowUp':
         if (activeItem > 0) {
           setActiveItem(activeItem - 1);
-          node?.scrollBy(0, -itemHeight!);
+          node?.scrollBy(0, -itemHeight);
         }
         break;
       case 'ArrowDown':
         if (activeItem < autoCompleteSearch.length - 1) {
           setActiveItem(activeItem + 1);
-          node?.scrollBy(0, itemHeight!);
+          node?.scrollBy(0, itemHeight);
         }
         break;
       case 'Enter':
@@ -102,7 +94,6 @@ const TagSelector = ({ selectedTag, setSelectedTag, ...styles }: Props) => {
         break;
       default:
         setActiveItem(0);
-      // break;
     }
   };
 
@@ -119,7 +110,7 @@ const TagSelector = ({ selectedTag, setSelectedTag, ...styles }: Props) => {
       <InputResult
         active={activeItem}
         ref={listRef}
-        inputResultVisible={inputResultVisible}
+        inputResultVisible={true}
         inputResults={autoCompleteSearch}
         onClick={handleClickResultItem}
       />

--- a/web/constants/alert.constants.ts
+++ b/web/constants/alert.constants.ts
@@ -1,8 +1,0 @@
-export const TEMP_TOKEN: string =
-  'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJyb2xlcyI6WyJST0xFX1VTRVIiXSwiaXNzIjoicHJncm1zIiwiZXhwIjoxNjYxNDkwOTc3LCJpYXQiOjE2NjAyODEzNzcsImVtYWlsIjoic2dtaW4yMDZAZ21haWwuY29tIn0.6nBJcGE49S0o4IJRWESVrKfRNkW4LNAlHduRwTyNOcjYmdTIP3uEXKb5_TfiyWeysMsX0KZntKbjFQ2VCx8eOQ';
-
-export const TEMP_USER_ID: number = 5;
-
-export const ALERT = {
-  ERROR: '문제가 발생했습니다.',
-};

--- a/web/pageComponents/folderdetailComponents/components/ContentSection/ContentSection.tsx
+++ b/web/pageComponents/folderdetailComponents/components/ContentSection/ContentSection.tsx
@@ -2,6 +2,9 @@ import * as S from './ContentSection.style';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { userInfo } from '../../../../recoil/user';
+import { getCookie } from '../../../../util/cookies';
 import { PAGE_URL } from '../../../../constants/url.constants';
 import { Profile, BookmarkList, Tag } from '../../../../components';
 import { SpecificFolder } from '../../../../types';
@@ -13,13 +16,6 @@ import {
   OriginFolderSection,
   PlaceholderSection,
 } from '../index';
-import {
-  TEMP_TOKEN,
-  TEMP_USER_ID,
-} from '../../../../constants/alert.constants';
-import { useRecoilValue } from 'recoil';
-import { userInfo } from '../../../../recoil/user';
-import { getCookie } from '../../../../util/cookies';
 
 interface Props {
   id?: number;
@@ -27,9 +23,10 @@ interface Props {
 
 const ContentSection = ({ id }: Props) => {
   const [data, setData] = useState<SpecificFolder>(undefined);
-  const router = useRouter();
-  const loginUser: any = useRecoilValue(userInfo);
+  const [isMyFolder, setIsMyFolder] = useState<boolean>(false);
+  const { user }: any = useRecoilValue(userInfo);
   const token = getCookie('ACCESS_TOKEN');
+  const router = useRouter();
 
   useEffect(() => {
     if (!id) return;
@@ -37,8 +34,8 @@ const ContentSection = ({ id }: Props) => {
     (async () => {
       try {
         const contentRes = await getFolder(id, token);
-        console.log(contentRes);
         setData(contentRes);
+        if (user) setIsMyFolder(user.id === contentRes.user.id);
       } catch (error) {
         console.log(error);
         router.push(PAGE_URL.ERROR);
@@ -51,7 +48,7 @@ const ContentSection = ({ id }: Props) => {
       {data ? (
         <S.Container>
           <S.TitleContainer>
-            {data.user.id === loginUser.user.id && (
+            {isMyFolder && (
               <PrivateSection
                 id={id}
                 isPrivate={data.isPrivate}
@@ -94,9 +91,9 @@ const ContentSection = ({ id }: Props) => {
               likes={data.likes}
               token={token}
               isLiked={data.isLiked}
-              disabled={data.user.id !== TEMP_USER_ID ? false : true}
+              disabled={isMyFolder}
             />
-            {data.user.id !== TEMP_USER_ID && (
+            {!isMyFolder && (
               <ScrapButtonSection id={id} data={data} token={token} />
             )}
           </S.ButtonsContainer>

--- a/web/pageComponents/folderdetailComponents/components/ContentSection/ContentSection.tsx
+++ b/web/pageComponents/folderdetailComponents/components/ContentSection/ContentSection.tsx
@@ -35,13 +35,18 @@ const ContentSection = ({ id }: Props) => {
       try {
         const contentRes = await getFolder(id, token);
         setData(contentRes);
-        if (user) setIsMyFolder(user.id === contentRes.user.id);
       } catch (error) {
         console.log(error);
         router.push(PAGE_URL.ERROR);
       }
     })();
   }, [id]);
+
+  useEffect(() => {
+    if (!data || !user) return;
+
+    setIsMyFolder(user.id === data.user.id);
+  }, [data, user]);
 
   return (
     <>

--- a/web/pageComponents/folderdetailComponents/components/ContentSection/ContentSection.tsx
+++ b/web/pageComponents/folderdetailComponents/components/ContentSection/ContentSection.tsx
@@ -24,7 +24,7 @@ interface Props {
 const ContentSection = ({ id }: Props) => {
   const [data, setData] = useState<SpecificFolder>(undefined);
   const [isMyFolder, setIsMyFolder] = useState<boolean>(false);
-  const { user }: any = useRecoilValue(userInfo);
+  const { user } = useRecoilValue(userInfo);
   const token = getCookie('ACCESS_TOKEN');
   const router = useRouter();
 

--- a/web/pageComponents/folderdetailComponents/components/LikeButtonSection/LikeButtonSection.tsx
+++ b/web/pageComponents/folderdetailComponents/components/LikeButtonSection/LikeButtonSection.tsx
@@ -1,7 +1,10 @@
 import { RoundButton } from '../index';
 import { createLike, deleteLike } from '../../../../apis/LikeAPI';
 import { useEffect, useState } from 'react';
-import { TEMP_USER_ID } from '../../../../constants/alert.constants';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { userInfo } from '../../../../recoil/user';
+import { showModalStatus } from '../../../../recoil/showModal';
+import { showLoginModal } from '../../../../constants/modal.constants';
 
 interface Props {
   folderId: number;
@@ -20,6 +23,8 @@ const LikeButtonSection = ({
 }: Props) => {
   const [isLikedValue, setIsLikedValue] = useState(isLiked);
   const [likesNum, setLikesNum] = useState(likes);
+  const setShowModalStatus = useSetRecoilState(showModalStatus);
+  const { user }: any = useRecoilValue(userInfo);
 
   useEffect(() => {
     setIsLikedValue(isLiked);
@@ -27,8 +32,14 @@ const LikeButtonSection = ({
   }, [isLiked, likes]);
 
   const handleClickAddLike = async () => {
+    if (!user) {
+      alert('로그인 후 가능합니다.');
+      setShowModalStatus(showLoginModal);
+      return;
+    }
+
     try {
-      await createLike(folderId, TEMP_USER_ID, token);
+      await createLike(folderId, user.id, token);
       setIsLikedValue(true);
       setLikesNum(likesNum + 1);
     } catch (error) {

--- a/web/pageComponents/folderdetailComponents/components/PrivateSection/PrivateSection.tsx
+++ b/web/pageComponents/folderdetailComponents/components/PrivateSection/PrivateSection.tsx
@@ -27,8 +27,8 @@ const PrivateSection = ({ id, isPrivate, isPinned, token }: Props) => {
       await router.push(PAGE_URL.MAIN);
     } catch (error) {
       console.log(error);
+      alert('문제가 발생했습니다.');
     }
-    console.log('delete');
   };
 
   return (

--- a/web/pageComponents/folderdetailComponents/components/ScrapButtonSection/ScrapButtonSection.tsx
+++ b/web/pageComponents/folderdetailComponents/components/ScrapButtonSection/ScrapButtonSection.tsx
@@ -1,5 +1,10 @@
 import { useRouter } from 'next/router';
+import { useSetRecoilState, useRecoilValue } from 'recoil';
 import { createFolder } from '../../../../apis/FolderAPI';
+import { showLoginModal } from '../../../../constants/modal.constants';
+import { PAGE_URL } from '../../../../constants/url.constants';
+import { showModalStatus } from '../../../../recoil/showModal';
+import { userInfo } from '../../../../recoil/user';
 import { SpecificFolder } from '../../../../types';
 import { CreateOrUpdateFolder } from '../../../../types/folder';
 import { RoundButton } from '../index';
@@ -12,8 +17,16 @@ interface Props {
 
 const ScrapButtonSection = ({ id, token, data }: Props) => {
   const router = useRouter();
+  const setShowModalStatus = useSetRecoilState(showModalStatus);
+  const { user }: any = useRecoilValue(userInfo);
 
   const handleClickScrap = async () => {
+    if (!user) {
+      alert('로그인 후 가능합니다.');
+      setShowModalStatus(showLoginModal);
+      return;
+    }
+
     const { title, image, content, isPinned, isPrivate, tags, bookmarks } =
       data;
     const folderData: CreateOrUpdateFolder = {
@@ -28,7 +41,7 @@ const ScrapButtonSection = ({ id, token, data }: Props) => {
     };
     try {
       const res = await createFolder(folderData, token);
-      await router.push(`/folderdetail/${res.id}`);
+      await router.push(`${PAGE_URL.DETAIL}/${res.id}`);
     } catch (error) {
       console.log(error);
     }

--- a/web/pageComponents/folderdetailComponents/components/ScrapButtonSection/ScrapButtonSection.tsx
+++ b/web/pageComponents/folderdetailComponents/components/ScrapButtonSection/ScrapButtonSection.tsx
@@ -44,6 +44,7 @@ const ScrapButtonSection = ({ id, token, data }: Props) => {
       await router.push(`${PAGE_URL.DETAIL}/${res.id}`);
     } catch (error) {
       console.log(error);
+      alert('문제가 발생했습니다.');
     }
   };
 

--- a/web/pages/folderdetail/[id].tsx
+++ b/web/pages/folderdetail/[id].tsx
@@ -1,5 +1,5 @@
-import { useRouter } from 'next/router';
 import * as S from '../../styles/pageStyles/folderDetail.style';
+import { useRouter } from 'next/router';
 import {
   CommentSection,
   ContentSection,

--- a/web/recoil/user.tsx
+++ b/web/recoil/user.tsx
@@ -1,6 +1,11 @@
 import { atom } from 'recoil';
+import { User } from '../types';
 
-export const userInfo = atom({
+interface IUserInfo {
+  user?: User;
+}
+
+export const userInfo = atom<IUserInfo>({
   key: 'userInfo',
   default: {},
 });

--- a/web/types/user.ts
+++ b/web/types/user.ts
@@ -27,12 +27,9 @@ export interface SignUpOrIn {
   password: string;
 }
 
-interface InterestsField {
-  field: string;
-}
 export interface UpdateInfo {
   name: string;
   image: string;
   introduce: string;
-  interests: InterestsField[] | [];
+  interests: string[] | [];
 }


### PR DESCRIPTION
# First Login Modal 로직 구현 + Comment 부분 수정
![image](https://user-images.githubusercontent.com/72294509/184472060-2654d391-a6ff-4929-a76c-a8537ed1fef7.png)
![image](https://user-images.githubusercontent.com/72294509/184472072-9422ef7f-39ec-492d-b121-482d15f0f472.png)

## Navigation Bar 아바타 수정
![image](https://user-images.githubusercontent.com/72294509/184472392-321c90f9-c9fe-4d07-b654-e404f43fbf97.png)


```
FisrtLogin Modal의 경우, 지금 첫번째 로그인이 아닐 때 띄워지게 해놨습니다. (테스트를 위한 용도)
배포 전, 첫번째 로그인일 경우에만 띄우도록 수정할 예정입니다.
```

## 📌 설명
- `First Login Modal` 로직 구현 (닉네임, 한줄소개, 태그, 프로필 사진 수정 모달)
- `Comment Input`, `Comment` Component API 연동 및 ACCESS_TOKEN + UserInfo Recoil 데이터 연동
- `Detail Page` ACCESS_TOKEN + UserInfo Recoil 데이터 연동

## 🎨 구현 내용
### 1. FirstLogIn Modal
- `TagSelector` Component 태그 미리 다 보여주게 수정
![image](https://user-images.githubusercontent.com/72294509/184472214-66e8aabf-f982-42d6-96e4-6e4cbe36cca6.png)

- 닉네임, 한줄소개, 태그, 프로필 사진 contextAPI를 통한 상태 관리 + 뒤로 가도 데이터 유지되게 구현
- 회원 정보 수정 API 연동

### 2. Detail Page
- 내 폴더일 경우, 좋아요 disabled 예외처리 + 스크랩 버튼 안보이게 수정
![image](https://user-images.githubusercontent.com/72294509/184472264-f58804f9-94cb-4f39-b348-814c0eed7ce8.png)

### 3. Comment Component / CommentInput Component
- 로그인을 하지 않은 사용자가 댓글+답글 작성을 누르면 alert + 로그인 모달 띄워주기
![image](https://user-images.githubusercontent.com/72294509/184472294-3a884974-9648-495d-a743-8cbc91c459d5.png)
![image](https://user-images.githubusercontent.com/72294509/184472299-4fb901b0-3d02-4f6f-8495-9f61e6724afb.png)

- 자신의 댓글인 경우 수정/삭제 가능
![image](https://user-images.githubusercontent.com/72294509/184472354-0ebaed40-34c0-42d9-bdd5-bedcf549e78b.png)
![image](https://user-images.githubusercontent.com/72294509/184472361-2cb5a02f-d4ce-421e-bed1-95c109d93460.png)


## ✅ 중점적으로 봐줬으면 하는 부분
### Comment Section쪽 낙관적 업데이트 필요합니다. 

## 🚀 연관된 이슈
Closes #92 