### PR TITLE
Feat: modal+navigation+user info page

### DIFF
--- a/web/components/Comment/Comment.tsx
+++ b/web/components/Comment/Comment.tsx
@@ -53,7 +53,12 @@ const CommentComponent = ({ comment, folderId }: Props) => {
           children?.map((child: Comment, index: number) => {
             return (
               <div key={child.id}>
-                <CommentItem comment={child} folderId={folderId} />
+                <CommentItem
+                  comment={child}
+                  folderId={folderId}
+                  userId={user && user.id}
+                  token={token}
+                />
                 {index !== children.length - 1 && <S.Line />}
               </div>
             );

--- a/web/components/ImageUpload/ImageUpload.style.ts
+++ b/web/components/ImageUpload/ImageUpload.style.ts
@@ -1,6 +1,5 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import Image from 'next/image';
 
 interface Props {
   version: 'modal' | 'page';

--- a/web/components/ImageUpload/ImageUpload.tsx
+++ b/web/components/ImageUpload/ImageUpload.tsx
@@ -69,7 +69,7 @@ const ImageUpload = ({ imageSrc, setImageSrc, version }: Props) => {
       >
         <S.FileLabel htmlFor="fileInput">
           {version === 'modal' ? (
-            <ModalPreview imgSrc={imgSrc} />
+            <ModalPreview imgSrc={imgSrc ? imgSrc : imageSrc} />
           ) : (
             <PagePreview imgSrc={imgSrc ? imgSrc : imageSrc} />
           )}

--- a/web/components/Layout.tsx
+++ b/web/components/Layout.tsx
@@ -22,8 +22,8 @@ const Layout = ({ token, children }: Props) => {
     if (token) {
       setLoginStatus(true);
       const fetch = async () => {
-        const userInfo: MyInfo = await getUserInfo(token);
-        setUserInfo(userInfo);
+        const loginUserInfo: MyInfo = await getUserInfo(token);
+        setUserInfo(loginUserInfo);
       };
       fetch();
     } else {

--- a/web/components/Modal/FirstLogin/FirstLogin.tsx
+++ b/web/components/Modal/FirstLogin/FirstLogin.tsx
@@ -39,7 +39,7 @@ const FirstLogin = () => {
           />
         );
       default:
-        return <Page05 handlePreviousPage={handlePreviousPage} />;
+        return <Page05 />;
     }
   };
 

--- a/web/components/Modal/FirstLogin/FirstLogin.tsx
+++ b/web/components/Modal/FirstLogin/FirstLogin.tsx
@@ -43,11 +43,7 @@ const FirstLogin = () => {
     }
   };
 
-  return (
-    <UserInfoProvider>
-      <InnerContainer>{switchPage(page)}</InnerContainer>
-    </UserInfoProvider>
-  );
+  return <UserInfoProvider>{switchPage(page)}</UserInfoProvider>;
 };
 
 export default FirstLogin;

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page01.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page01.tsx
@@ -28,6 +28,7 @@ const Page01 = ({ handleNextPage }: Props) => {
 
   useEffect(() => {
     nameRef.current.value = userInfo.name;
+    nameRef.current.focus();
   }, [userInfo]);
 
   return (

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page01.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page01.tsx
@@ -13,6 +13,8 @@ const Page01 = ({ handleNextPage }: Props) => {
   const { userInfo, setUserName } = useUserInfo();
 
   const handleClickStoreName: FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+
     const nameValue = nameRef.current.value;
     const res = setUserName(nameValue);
 

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page01.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page01.tsx
@@ -1,10 +1,10 @@
-import { MouseEventHandler, useEffect, useRef, useState } from 'react';
 import * as S from '../../Modal.style';
+import { FormEventHandler, useEffect, useRef, useState } from 'react';
 import { Input, Button } from '../../../index';
 import { useUserInfo } from '../contexts/UserInfoProvider';
 
 interface Props {
-  handleNextPage: MouseEventHandler;
+  handleNextPage: FormEventHandler;
 }
 
 const Page01 = ({ handleNextPage }: Props) => {
@@ -12,7 +12,7 @@ const Page01 = ({ handleNextPage }: Props) => {
   const [errorText, setErrorText] = useState('');
   const { userInfo, setUserName } = useUserInfo();
 
-  const handleClickStoreName: MouseEventHandler = (e) => {
+  const handleClickStoreName: FormEventHandler<HTMLFormElement> = (e) => {
     const nameValue = nameRef.current.value;
     const res = setUserName(nameValue);
 
@@ -29,7 +29,7 @@ const Page01 = ({ handleNextPage }: Props) => {
   }, [userInfo]);
 
   return (
-    <>
+    <S.FormContainer onSubmit={handleClickStoreName}>
       <S.Title>
         <br />
         <S.MainText>Linkbook</S.MainText>에 오신 것을 환영해요! 🎉
@@ -43,11 +43,9 @@ const Page01 = ({ handleNextPage }: Props) => {
         errorText={errorText}
       />
       <S.ButtonContainer>
-        <Button type="button" onClick={handleClickStoreName}>
-          다음 &gt;
-        </Button>
+        <Button type="submit">다음 &gt;</Button>
       </S.ButtonContainer>
-    </>
+    </S.FormContainer>
   );
 };
 

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page02.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page02.tsx
@@ -35,6 +35,7 @@ const Page02 = ({ handleNextPage, handlePreviousPage }: Props) => {
 
   useEffect(() => {
     introduceRef.current.value = userInfo.introduce;
+    introduceRef.current.focus();
   }, [userInfo]);
 
   return (

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page02.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page02.tsx
@@ -20,6 +20,8 @@ const Page02 = ({ handleNextPage, handlePreviousPage }: Props) => {
   const { userInfo, setUserIntroduce } = useUserInfo();
 
   const handleClickStoreIntroduce: FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+
     const introduceValue = introduceRef.current.value;
     const res = setUserIntroduce(introduceValue);
 

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page02.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page02.tsx
@@ -1,10 +1,16 @@
-import { MouseEventHandler, useEffect, useRef, useState } from 'react';
 import * as S from '../../Modal.style';
 import { Button, Input, Icon } from '../../../index';
 import { useUserInfo } from '../contexts/UserInfoProvider';
+import {
+  FormEventHandler,
+  MouseEventHandler,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 interface Props {
-  handleNextPage: MouseEventHandler;
+  handleNextPage: FormEventHandler;
   handlePreviousPage: MouseEventHandler;
 }
 
@@ -13,7 +19,7 @@ const Page02 = ({ handleNextPage, handlePreviousPage }: Props) => {
   const [errorText, setErrorText] = useState('');
   const { userInfo, setUserIntroduce } = useUserInfo();
 
-  const handleClickStoreIntroduce: MouseEventHandler = (e) => {
+  const handleClickStoreIntroduce: FormEventHandler<HTMLFormElement> = (e) => {
     const introduceValue = introduceRef.current.value;
     const res = setUserIntroduce(introduceValue);
 
@@ -30,7 +36,7 @@ const Page02 = ({ handleNextPage, handlePreviousPage }: Props) => {
   }, [userInfo]);
 
   return (
-    <>
+    <S.FormContainer onSubmit={handleClickStoreIntroduce}>
       <S.PreviousButton onClick={handlePreviousPage}>
         <Icon name="arrowLeft" size={30} />
       </S.PreviousButton>
@@ -47,11 +53,9 @@ const Page02 = ({ handleNextPage, handlePreviousPage }: Props) => {
         errorText={errorText}
       />
       <S.ButtonContainer>
-        <Button type="button" onClick={handleClickStoreIntroduce}>
-          다음 &gt;
-        </Button>
+        <Button type="submit">다음 &gt;</Button>
       </S.ButtonContainer>
-    </>
+    </S.FormContainer>
   );
 };
 

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page03.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page03.tsx
@@ -1,10 +1,15 @@
 import * as S from '../../Modal.style';
-import { MouseEventHandler, useEffect, useState } from 'react';
+import {
+  FormEventHandler,
+  MouseEventHandler,
+  useEffect,
+  useState,
+} from 'react';
 import { Button, Icon, TagSelector } from '../../../index';
 import { useUserInfo } from '../contexts/UserInfoProvider';
 
 interface Props {
-  handleNextPage: MouseEventHandler;
+  handleNextPage: FormEventHandler;
   handlePreviousPage: MouseEventHandler;
 }
 
@@ -12,7 +17,7 @@ const Page03 = ({ handleNextPage, handlePreviousPage }: Props) => {
   const { userInfo, setUserInterests } = useUserInfo();
   const [selectedTag, setSelectedTag] = useState([]);
 
-  const handleClickStoreInterests: MouseEventHandler = (e) => {
+  const handleClickStoreInterests: FormEventHandler<HTMLFormElement> = (e) => {
     setUserInterests(selectedTag);
     handleNextPage(e);
   };
@@ -22,7 +27,7 @@ const Page03 = ({ handleNextPage, handlePreviousPage }: Props) => {
   }, [userInfo]);
 
   return (
-    <>
+    <S.FormContainer onSubmit={handleClickStoreInterests}>
       <S.PreviousButton onClick={handlePreviousPage}>
         <Icon name="arrowLeft" size={30} />
       </S.PreviousButton>
@@ -41,11 +46,9 @@ const Page03 = ({ handleNextPage, handlePreviousPage }: Props) => {
         />
       </S.TagSelectorWrapper>
       <S.ButtonContainer>
-        <Button type="button" onClick={handleClickStoreInterests}>
-          다음 &gt;
-        </Button>
+        <Button type="submit">다음 &gt;</Button>
       </S.ButtonContainer>
-    </>
+    </S.FormContainer>
   );
 };
 

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page03.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page03.tsx
@@ -18,6 +18,8 @@ const Page03 = ({ handleNextPage, handlePreviousPage }: Props) => {
   const [selectedTag, setSelectedTag] = useState([]);
 
   const handleClickStoreInterests: FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+
     setUserInterests(selectedTag);
     handleNextPage(e);
   };

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page04.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page04.tsx
@@ -41,6 +41,7 @@ const Page04 = ({ handleNextPage, handlePreviousPage }: Props) => {
     } catch (error) {
       console.log(error);
       alert('문제가 발생했습니다.');
+      return;
     }
 
     handleNextPage(e);

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page04.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page04.tsx
@@ -1,5 +1,10 @@
 import * as S from '../../Modal.style';
-import { MouseEventHandler, useEffect, useState } from 'react';
+import {
+  KeyboardEventHandler,
+  MouseEventHandler,
+  useEffect,
+  useState,
+} from 'react';
 import { Button, ImageUpload, Icon } from '../../../index';
 import { useUserInfo } from '../contexts/UserInfoProvider';
 import { getUserInfo, updateUserInfo } from '../../../../apis/UserAPI';
@@ -46,7 +51,7 @@ const Page04 = ({ handleNextPage, handlePreviousPage }: Props) => {
   }, [userInfo]);
 
   return (
-    <>
+    <S.InnerContainer>
       <S.PreviousButton onClick={handlePreviousPage}>
         <Icon name="arrowLeft" size={30} />
       </S.PreviousButton>
@@ -67,7 +72,7 @@ const Page04 = ({ handleNextPage, handlePreviousPage }: Props) => {
           다음 &gt;
         </Button>
       </S.ButtonContainer>
-    </>
+    </S.InnerContainer>
   );
 };
 

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page04.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page04.tsx
@@ -1,10 +1,5 @@
 import * as S from '../../Modal.style';
-import {
-  KeyboardEventHandler,
-  MouseEventHandler,
-  useEffect,
-  useState,
-} from 'react';
+import { MouseEventHandler, useEffect, useState } from 'react';
 import { Button, ImageUpload, Icon } from '../../../index';
 import { useUserInfo } from '../contexts/UserInfoProvider';
 import { getUserInfo, updateUserInfo } from '../../../../apis/UserAPI';

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page05.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page05.tsx
@@ -14,7 +14,7 @@ const Page05 = () => {
   };
 
   return (
-    <>
+    <S.InnerContainer>
       <S.Title>
         <br />
         <br />
@@ -28,7 +28,7 @@ const Page05 = () => {
           <S.LogoText>링북</S.LogoText> 100% 활용법 &gt;
         </S.ConfirmButton>
       </S.ButtonContainer>
-    </>
+    </S.InnerContainer>
   );
 };
 

--- a/web/components/Modal/FirstLogin/FirstLoginPage/Page05.tsx
+++ b/web/components/Modal/FirstLogin/FirstLoginPage/Page05.tsx
@@ -1,19 +1,20 @@
 import * as S from '../../Modal.style';
-import Link from 'next/link';
-import { MouseEventHandler } from 'react';
-import { Icon } from '../../../index';
 import { PAGE_URL } from '../../../../constants/url.constants';
+import { useRouter } from 'next/router';
+import { useResetRecoilState } from 'recoil';
+import { showModalStatus } from '../../../../recoil/showModal';
 
-interface Props {
-  handlePreviousPage: MouseEventHandler;
-}
+const Page05 = () => {
+  const resetShowModal = useResetRecoilState(showModalStatus);
+  const router = useRouter();
 
-const Page05 = ({ handlePreviousPage }: Props) => {
+  const handleClickMoveInfoPage = () => {
+    router.push(PAGE_URL.INFO);
+    resetShowModal();
+  };
+
   return (
     <>
-      <S.PreviousButton onClick={handlePreviousPage}>
-        <Icon name="arrowLeft" size={30} />
-      </S.PreviousButton>
       <S.Title>
         <br />
         <br />
@@ -23,11 +24,9 @@ const Page05 = ({ handlePreviousPage }: Props) => {
         <S.MainText>북마크 폴더</S.MainText>를 등록하러 가 볼까요?
       </S.Title>
       <S.ButtonContainer>
-        <Link href={PAGE_URL.INFO} passHref>
-          <S.ConfirmButton type="button">
-            <S.LogoText>링북</S.LogoText> 100% 활용법 &gt;
-          </S.ConfirmButton>
-        </Link>
+        <S.ConfirmButton type="button" onClick={handleClickMoveInfoPage}>
+          <S.LogoText>링북</S.LogoText> 100% 활용법 &gt;
+        </S.ConfirmButton>
       </S.ButtonContainer>
     </>
   );

--- a/web/components/Modal/FirstLogin/contexts/UserInfoProvider.tsx
+++ b/web/components/Modal/FirstLogin/contexts/UserInfoProvider.tsx
@@ -29,8 +29,8 @@ const UserInfoProvider = ({ children }: any) => {
   const [userInfo, setUserInfo] = useState(defaultValue);
 
   const setUserName = (nameValue: string) => {
-    const nameLen = nameValue.length;
-    if (!validateName(nameLen)) return '1-8자 사이의 길이로 입력해주세요.';
+    const isValidateName = validateName(nameValue.length);
+    if (!isValidateName.status) return isValidateName.error;
 
     setUserInfo({
       ...userInfo,
@@ -41,9 +41,8 @@ const UserInfoProvider = ({ children }: any) => {
   };
 
   const setUserIntroduce = (introduceValue: string) => {
-    const introduceLen = introduceValue.length;
-    if (!validateIntroduce(introduceLen))
-      return '1-50자 사이의 길이로 입력해주세요.';
+    const isValidateIntroduce = validateIntroduce(introduceValue.length);
+    if (!isValidateIntroduce.status) return isValidateIntroduce.error;
 
     setUserInfo({
       ...userInfo,
@@ -63,15 +62,15 @@ const UserInfoProvider = ({ children }: any) => {
   };
 
   const getUpdatedUserInfo = (imageSrc: string) => {
-    const imageLen = imageSrc.length;
-    if (!validateImage(imageLen)) return '이미지를 업로드해주세요.';
+    const isValidateImage = validateImage(imageSrc.length);
+    if (!isValidateImage.status) return isValidateImage.error;
 
     const finalUserInfo = {
       ...userInfo,
       image: imageSrc,
     };
-
     setUserInfo(finalUserInfo);
+
     return finalUserInfo;
   };
 

--- a/web/components/Modal/FirstLogin/contexts/UserInfoProvider.tsx
+++ b/web/components/Modal/FirstLogin/contexts/UserInfoProvider.tsx
@@ -1,5 +1,10 @@
 import { createContext, useContext, useState } from 'react';
 import { UpdateInfo } from '../../../../types';
+import {
+  validateImage,
+  validateIntroduce,
+  validateName,
+} from '../../../../util/validateUserInfo';
 
 interface IUserInfoContext {
   userInfo: UpdateInfo;
@@ -25,8 +30,7 @@ const UserInfoProvider = ({ children }: any) => {
 
   const setUserName = (nameValue: string) => {
     const nameLen = nameValue.length;
-    if (nameLen > 8 || nameLen === 0)
-      return '1-8자 사이의 길이로 입력해주세요.';
+    if (!validateName(nameLen)) return '1-8자 사이의 길이로 입력해주세요.';
 
     setUserInfo({
       ...userInfo,
@@ -38,7 +42,7 @@ const UserInfoProvider = ({ children }: any) => {
 
   const setUserIntroduce = (introduceValue: string) => {
     const introduceLen = introduceValue.length;
-    if (introduceLen > 50 || introduceLen === 0)
+    if (!validateIntroduce(introduceLen))
       return '1-50자 사이의 길이로 입력해주세요.';
 
     setUserInfo({
@@ -60,7 +64,7 @@ const UserInfoProvider = ({ children }: any) => {
 
   const getUpdatedUserInfo = (imageSrc: string) => {
     const imageLen = imageSrc.length;
-    if (imageLen === 0) return '이미지를 업로드해주세요.';
+    if (!validateImage(imageLen)) return '이미지를 업로드해주세요.';
 
     const finalUserInfo = {
       ...userInfo,

--- a/web/components/Modal/Login/Login.tsx
+++ b/web/components/Modal/Login/Login.tsx
@@ -48,7 +48,7 @@ const Login = () => {
       setUserInfo(userInfoValue);
       setLoginStatus(true);
 
-      if (!isFirstLogin) {
+      if (isFirstLogin) {
         setShowModalStatus(showFirstModal);
         return;
       }

--- a/web/components/Modal/Modal.style.ts
+++ b/web/components/Modal/Modal.style.ts
@@ -137,6 +137,12 @@ export const InputContainer = styled.div`
   gap: 20px;
 `;
 
+export const UserInputContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+`;
+
 export const ImageUploadWrapper = styled.div`
   width: fit-content;
   margin: 10px auto 0 auto;

--- a/web/components/Modal/SignUp/SignUpPage/Page01.tsx
+++ b/web/components/Modal/SignUp/SignUpPage/Page01.tsx
@@ -16,6 +16,7 @@ interface EmailInput {
 
 const Page01 = ({ handlePage }: Props) => {
   const [emailValue, setEmailValue] = useState('');
+  const [isValidate, setIsValidate] = useState(false);
   const { setEmail } = useUserInfo();
   const keyRef = useRef<HTMLInputElement>(null);
   const {
@@ -24,23 +25,27 @@ const Page01 = ({ handlePage }: Props) => {
     formState: { errors },
   } = useForm<EmailInput>();
 
-  const onSubmit: SubmitHandler<EmailInput> = useCallback(async (data) => {
-    const { email } = data;
+  const handleSubmitInputData: SubmitHandler<EmailInput> = useCallback(
+    async (data) => {
+      const { email } = data;
 
-    try {
-      await requestEmailKey(email);
-      setEmailValue(email);
-      alert('입력한 이메일로 인증 코드가 전송되었습니다.');
-    } catch (error) {
-      alert('문제가 발생했습니다. 다시 시도해주세요.');
-      console.log(error);
-    }
-  }, []);
+      try {
+        await requestEmailKey(email);
+        setEmailValue(email);
+        alert('입력한 이메일로 인증 코드가 전송되었습니다.');
+      } catch (error) {
+        alert('문제가 발생했습니다. 다시 시도해주세요.');
+        console.log(error);
+      }
+    },
+    [],
+  );
 
-  const onValidateKey = async () => {
+  const handleClickValidateKey = async () => {
     try {
       await validateEmailKey(emailValue, keyRef.current.value);
       alert('인증되었습니다.');
+      setIsValidate(true);
       setEmail(emailValue);
     } catch (error) {
       alert('인증코드가 일치하지 않습니다.');
@@ -48,8 +53,18 @@ const Page01 = ({ handlePage }: Props) => {
     }
   };
 
+  const handleClickCheckValidate: MouseEventHandler = (e) => {
+    console.log(isValidate);
+    if (!isValidate) {
+      alert('이메일 인증을 먼저 진행해주세요.');
+      return;
+    }
+
+    handlePage(e);
+  };
+
   return (
-    <S.FormContainer onSubmit={handleSubmit(onSubmit)}>
+    <S.FormContainer onSubmit={handleSubmit(handleSubmitInputData)}>
       <S.Title>
         <S.MainText>Linkbook</S.MainText>에 처음 오셨군요! 🎉
         <br />
@@ -75,13 +90,17 @@ const Page01 = ({ handlePage }: Props) => {
           type="text"
           ref={keyRef}
         >
-          <Button type="button" version="modal" onClick={onValidateKey}>
+          <Button
+            type="button"
+            version="modal"
+            onClick={handleClickValidateKey}
+          >
             인증
           </Button>
         </Input>
       </S.InputContainer>
       <S.ButtonContainer>
-        <Button type="button" onClick={handlePage}>
+        <Button type="button" onClick={handleClickCheckValidate}>
           다음 &gt;
         </Button>
       </S.ButtonContainer>

--- a/web/components/Modal/User/User.tsx
+++ b/web/components/Modal/User/User.tsx
@@ -1,12 +1,12 @@
+import UserInfoProvider from './contexts/UserInfoProvider';
 import { useState } from 'react';
 import { Page01, Page02 } from './UserPage';
-import UpdateUserProvider from './contexts/UpdateUserProvider';
 import { getCookie } from '../../../util/cookies';
-import { useRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import { userInfo } from '../../../recoil/user';
 
 const User = () => {
-  const [userInfoState, setUserInfoState] = useRecoilState(userInfo);
+  const userInfoState = useRecoilValue(userInfo);
   const token = getCookie('ACCESS_TOKEN');
 
   const [page, setPage] = useState(0);
@@ -32,7 +32,7 @@ const User = () => {
     }
   };
 
-  return <UpdateUserProvider>{switchPage(page)}</UpdateUserProvider>;
+  return <UserInfoProvider>{switchPage(page)}</UserInfoProvider>;
 };
 
 export default User;

--- a/web/components/Modal/User/User.tsx
+++ b/web/components/Modal/User/User.tsx
@@ -1,32 +1,38 @@
-import { Button, Input, ImageUpload } from '../../index';
-import * as S from '../Modal.style';
+import { useState } from 'react';
+import { Page01, Page02 } from './UserPage';
+import UpdateUserProvider from './contexts/UpdateUserProvider';
+import { getCookie } from '../../../util/cookies';
+import { useRecoilState } from 'recoil';
+import { userInfo } from '../../../recoil/user';
 
 const User = () => {
-  const handleUpdate = () => {
-    console.log('회원정보 수정 완료');
+  const [userInfoState, setUserInfoState] = useRecoilState(userInfo);
+  const token = getCookie('ACCESS_TOKEN');
+
+  const [page, setPage] = useState(0);
+
+  const handleNextPage = () => {
+    setPage(page + 1);
   };
 
-  return (
-    <S.InnerContainer>
-      <S.Title>
-        Haeyum님 만의 멋있는 <br />
-        <S.MainText>프로필 사진</S.MainText>과 <S.MainText>닉네임</S.MainText>을
-        입력해주세요.
-      </S.Title>
-      <S.ImageUploadWrapper>
-        <ImageUpload version="modal" />
-      </S.ImageUploadWrapper>
-      <S.InputContainer>
-        <Input placeholder="변경할 닉네임" type="text" />
-        <Input placeholder="변경할 한 줄 소개" type="text" />
-      </S.InputContainer>
-      <S.ButtonContainer>
-        <Button type="button" onClick={handleUpdate}>
-          수정
-        </Button>
-      </S.ButtonContainer>
-    </S.InnerContainer>
-  );
+  const switchPage = (pageNum: number) => {
+    switch (pageNum) {
+      case 0:
+        return (
+          <Page01
+            handlePage={handleNextPage}
+            token={token}
+            userData={userInfoState.user}
+          />
+        );
+      case 1:
+        return <Page02 token={token} userData={userInfoState.user} />;
+      default:
+        return <></>;
+    }
+  };
+
+  return <UpdateUserProvider>{switchPage(page)}</UpdateUserProvider>;
 };
 
 export default User;

--- a/web/components/Modal/User/UserPage/Page01.tsx
+++ b/web/components/Modal/User/UserPage/Page01.tsx
@@ -1,0 +1,129 @@
+import * as S from '../../Modal.style';
+import { MouseEventHandler, useEffect, useRef, useState } from 'react';
+import { Button, Input, ImageUpload } from '../../../index';
+import { useResetRecoilState, useSetRecoilState } from 'recoil';
+import { userInfo } from '../../../../recoil/user';
+import { useUpdateUser } from '../contexts/UpdateUserProvider';
+import { getUserInfo, updateUserInfo } from '../../../../apis/UserAPI';
+import { showModalStatus } from '../../../../recoil/showModal';
+import { User } from '../../../../types';
+
+interface Props {
+  handlePage: MouseEventHandler;
+  token: string;
+  userData: User;
+}
+
+const Page01 = ({ handlePage, token, userData }: Props) => {
+  const { validateUserInfo, setUserBasicInfo } = useUpdateUser();
+  const setUserInfoState = useSetRecoilState(userInfo);
+  const closeModal = useResetRecoilState(showModalStatus);
+
+  const nameRef = useRef<HTMLInputElement>(null);
+  const introduceRef = useRef<HTMLInputElement>(null);
+
+  const [imageSrc, setImageSrc] = useState('');
+  const [errorText, setErrorText] = useState({
+    name: '',
+    introduce: '',
+    image: '',
+  });
+
+  const handleStoreUserInfo: MouseEventHandler<HTMLInputElement> = (e) => {
+    const storeUserData = {
+      name: nameRef.current.value,
+      introduce: introduceRef.current.value,
+      image: imageSrc,
+    };
+
+    const errorText = validateUserInfo(storeUserData);
+    const { name, introduce, image } = errorText;
+
+    if (!name && !introduce && !image) {
+      setUserBasicInfo(storeUserData);
+      handlePage(e);
+      return;
+    }
+
+    setErrorText(errorText);
+  };
+
+  const handleUpdateUserInfo = async () => {
+    const updateUserData = {
+      name: nameRef.current.value,
+      introduce: introduceRef.current.value,
+      image: imageSrc,
+      interests: userData.interests,
+    };
+
+    try {
+      await updateUserInfo(updateUserData, token);
+
+      const newUserInfo = await getUserInfo(token);
+      setUserInfoState(newUserInfo);
+      closeModal();
+    } catch (error) {
+      console.log(error);
+      alert('문제가 발생했습니다.');
+    }
+  };
+
+  useEffect(() => {
+    if (!userData) return;
+
+    nameRef.current.value = userData.name;
+    introduceRef.current.value = userData.introduce;
+    setImageSrc(userData.image);
+
+    nameRef.current.focus();
+  }, [userData]);
+
+  return (
+    <>
+      {userData && (
+        <S.InnerContainer>
+          <S.Title>
+            {userData.name}님의 <br />
+            <S.MainText>수정할 정보</S.MainText>를 입력해주세요.
+          </S.Title>
+          <S.ImageUploadWrapper>
+            <ImageUpload
+              version="modal"
+              imageSrc={imageSrc}
+              setImageSrc={setImageSrc}
+            />
+            {errorText.image && <S.ErrorText>{errorText.image}</S.ErrorText>}
+          </S.ImageUploadWrapper>
+          <S.UserInputContainer>
+            <Input
+              placeholder="변경할 닉네임"
+              type="text"
+              ref={nameRef}
+              errorText={errorText.name}
+            />
+            <Input
+              placeholder="변경할 한 줄 소개"
+              type="text"
+              ref={introduceRef}
+              errorText={errorText.introduce}
+            />
+          </S.UserInputContainer>
+          <S.ButtonContainer>
+            <Button type="button" onClick={handleUpdateUserInfo}>
+              수정 완료
+            </Button>
+            <Button
+              type="button"
+              onClick={handleStoreUserInfo}
+              version="mainLight"
+            >
+              관심 태그 수정
+            </Button>
+          </S.ButtonContainer>
+        </S.InnerContainer>
+      )}
+    </>
+  );
+};
+
+export default Page01;

--- a/web/components/Modal/User/UserPage/Page01.tsx
+++ b/web/components/Modal/User/UserPage/Page01.tsx
@@ -3,7 +3,7 @@ import { MouseEventHandler, useEffect, useRef, useState } from 'react';
 import { Button, Input, ImageUpload } from '../../../index';
 import { useResetRecoilState, useSetRecoilState } from 'recoil';
 import { userInfo } from '../../../../recoil/user';
-import { useUpdateUser } from '../contexts/UpdateUserProvider';
+import { useUserInfo } from '../contexts/UserInfoProvider';
 import { getUserInfo, updateUserInfo } from '../../../../apis/UserAPI';
 import { showModalStatus } from '../../../../recoil/showModal';
 import { User } from '../../../../types';
@@ -15,7 +15,7 @@ interface Props {
 }
 
 const Page01 = ({ handlePage, token, userData }: Props) => {
-  const { validateUserInfo, setUserBasicInfo } = useUpdateUser();
+  const { validateUserInfo, setBasicUserInfo } = useUserInfo();
   const setUserInfoState = useSetRecoilState(userInfo);
   const closeModal = useResetRecoilState(showModalStatus);
 
@@ -40,7 +40,7 @@ const Page01 = ({ handlePage, token, userData }: Props) => {
     const { name, introduce, image } = errorText;
 
     if (!name && !introduce && !image) {
-      setUserBasicInfo(storeUserData);
+      setBasicUserInfo(storeUserData);
       handlePage(e);
       return;
     }

--- a/web/components/Modal/User/UserPage/Page02.tsx
+++ b/web/components/Modal/User/UserPage/Page02.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { Button, TagSelector } from '../../../index';
 import { useResetRecoilState, useSetRecoilState } from 'recoil';
 import { userInfo } from '../../../../recoil/user';
-import { useUpdateUser } from '../contexts/UpdateUserProvider';
+import { useUserInfo } from '../contexts/UserInfoProvider';
 import { showModalStatus } from '../../../../recoil/showModal';
 import { User } from '../../../../types';
 import { getUserInfo, updateUserInfo } from '../../../../apis/UserAPI';
@@ -16,7 +16,7 @@ interface Props {
 const Page02 = ({ token, userData }: Props) => {
   const setUserInfoState = useSetRecoilState(userInfo);
   const closeModal = useResetRecoilState(showModalStatus);
-  const { getUpdatedUserInfo, removeUserInfo } = useUpdateUser();
+  const { getUpdatedUserInfo, removeUserInfo } = useUserInfo();
   const [selectedTag, setSelectedTag] = useState([]);
 
   const handleUpdate = async () => {

--- a/web/components/Modal/User/UserPage/Page02.tsx
+++ b/web/components/Modal/User/UserPage/Page02.tsx
@@ -1,0 +1,75 @@
+import * as S from '../../Modal.style';
+import { useEffect, useState } from 'react';
+import { Button, TagSelector } from '../../../index';
+import { useResetRecoilState, useSetRecoilState } from 'recoil';
+import { userInfo } from '../../../../recoil/user';
+import { useUpdateUser } from '../contexts/UpdateUserProvider';
+import { showModalStatus } from '../../../../recoil/showModal';
+import { User } from '../../../../types';
+import { getUserInfo, updateUserInfo } from '../../../../apis/UserAPI';
+
+interface Props {
+  token: string;
+  userData: User;
+}
+
+const Page02 = ({ token, userData }: Props) => {
+  const setUserInfoState = useSetRecoilState(userInfo);
+  const closeModal = useResetRecoilState(showModalStatus);
+  const { getUpdatedUserInfo, removeUserInfo } = useUpdateUser();
+  const [selectedTag, setSelectedTag] = useState([]);
+
+  const handleUpdate = async () => {
+    const updateUserData = getUpdatedUserInfo(selectedTag);
+
+    try {
+      await updateUserInfo(updateUserData, token);
+
+      const newUserInfo = await getUserInfo(token);
+      setUserInfoState(newUserInfo);
+      closeModal();
+    } catch (error) {
+      console.log(error);
+      alert('문제가 발생했습니다.');
+    }
+  };
+
+  const handleCancelUpdate = () => {
+    removeUserInfo();
+    closeModal();
+  };
+
+  useEffect(() => {
+    if (!userData) return;
+
+    setSelectedTag(userData.interests);
+  }, [userData]);
+
+  return (
+    <>
+      {userData && (
+        <S.InnerContainer>
+          <S.Title>
+            수정하고 싶은
+            <br />
+            <S.MainText>관심사 태그</S.MainText>를 선택해주세요.
+          </S.Title>
+          <TagSelector
+            selectedTag={selectedTag}
+            setSelectedTag={setSelectedTag}
+          />
+          <S.ButtonContainer>
+            <Button type="button" onClick={handleCancelUpdate}>
+              수정 취소
+            </Button>
+            <Button type="button" onClick={handleUpdate}>
+              수정 완료
+            </Button>
+          </S.ButtonContainer>
+        </S.InnerContainer>
+      )}
+    </>
+  );
+};
+
+export default Page02;

--- a/web/components/Modal/User/UserPage/index.ts
+++ b/web/components/Modal/User/UserPage/index.ts
@@ -1,0 +1,2 @@
+export { default as Page01 } from './Page01';
+export { default as Page02 } from './Page02';

--- a/web/components/Modal/User/contexts/UpdateUserProvider.tsx
+++ b/web/components/Modal/User/contexts/UpdateUserProvider.tsx
@@ -1,0 +1,88 @@
+import { createContext, useContext, useState } from 'react';
+import { UpdateInfo } from '../../../../types';
+import {
+  validateImage,
+  validateIntroduce,
+  validateName,
+} from '../../../../util/validateUserInfo';
+
+interface IUpdateUserContext {
+  updateUser: UpdateInfo;
+  setUpdateUser: Function;
+  validateUserInfo: Function;
+  setUserBasicInfo: Function;
+  getUpdatedUserInfo: Function;
+  removeUserInfo: Function;
+}
+
+interface BasicUserInfo {
+  name: string;
+  introduce: string;
+  image: string;
+}
+
+const UpdateUserContext = createContext<IUpdateUserContext>(null);
+export const useUpdateUser = () => useContext(UpdateUserContext);
+
+const UpdateUserProvider = ({ children }: any) => {
+  const defaultValue: UpdateInfo = {
+    name: '',
+    introduce: '',
+    interests: [],
+    image: '',
+  };
+  const [updateUser, setUpdateUser] = useState(defaultValue);
+
+  const validateUserInfo = ({ name, introduce, image }: BasicUserInfo) => {
+    const nameLen = name.length;
+    const introduceLen = introduce.length;
+    const imageLen = image.length;
+
+    return {
+      name: !validateName(nameLen)
+        ? '1-8자 사이의 길이로 입력해주세요.'
+        : false,
+      introduce: !validateIntroduce(introduceLen)
+        ? '1-50자 사이의 길이로 입력해주세요.'
+        : false,
+      image: !validateImage(imageLen) ? '이미지를 업로드해주세요.' : false,
+    };
+  };
+
+  const setUserBasicInfo = ({ name, introduce, image }: BasicUserInfo) => {
+    setUpdateUser({
+      ...updateUser,
+      name,
+      introduce,
+      image,
+    });
+  };
+
+  const getUpdatedUserInfo = (tags: string[]) => {
+    return {
+      ...updateUser,
+      interests: tags,
+    };
+  };
+
+  const removeUserInfo = () => {
+    setUpdateUser(defaultValue);
+  };
+
+  return (
+    <UpdateUserContext.Provider
+      value={{
+        updateUser,
+        setUpdateUser,
+        validateUserInfo,
+        setUserBasicInfo,
+        getUpdatedUserInfo,
+        removeUserInfo,
+      }}
+    >
+      {children}
+    </UpdateUserContext.Provider>
+  );
+};
+
+export default UpdateUserProvider;

--- a/web/components/Modal/User/contexts/UserInfoProvider.tsx
+++ b/web/components/Modal/User/contexts/UserInfoProvider.tsx
@@ -6,11 +6,11 @@ import {
   validateName,
 } from '../../../../util/validateUserInfo';
 
-interface IUpdateUserContext {
-  updateUser: UpdateInfo;
-  setUpdateUser: Function;
+interface IUserInfoContext {
+  updatedUserInfo: UpdateInfo;
+  setUpdatedUserInfo: Function;
   validateUserInfo: Function;
-  setUserBasicInfo: Function;
+  setBasicUserInfo: Function;
   getUpdatedUserInfo: Function;
   removeUserInfo: Function;
 }
@@ -21,17 +21,17 @@ interface BasicUserInfo {
   image: string;
 }
 
-const UpdateUserContext = createContext<IUpdateUserContext>(null);
-export const useUpdateUser = () => useContext(UpdateUserContext);
+const UserInfoContext = createContext<IUserInfoContext>(null);
+export const useUserInfo = () => useContext(UserInfoContext);
 
-const UpdateUserProvider = ({ children }: any) => {
+const UserInfoProvider = ({ children }: any) => {
   const defaultValue: UpdateInfo = {
     name: '',
     introduce: '',
     interests: [],
     image: '',
   };
-  const [updateUser, setUpdateUser] = useState(defaultValue);
+  const [updatedUserInfo, setUpdatedUserInfo] = useState(defaultValue);
 
   const validateUserInfo = ({ name, introduce, image }: BasicUserInfo) => {
     const nameLen = name.length;
@@ -49,9 +49,9 @@ const UpdateUserProvider = ({ children }: any) => {
     };
   };
 
-  const setUserBasicInfo = ({ name, introduce, image }: BasicUserInfo) => {
-    setUpdateUser({
-      ...updateUser,
+  const setBasicUserInfo = ({ name, introduce, image }: BasicUserInfo) => {
+    setUpdatedUserInfo({
+      ...updatedUserInfo,
       name,
       introduce,
       image,
@@ -60,29 +60,29 @@ const UpdateUserProvider = ({ children }: any) => {
 
   const getUpdatedUserInfo = (tags: string[]) => {
     return {
-      ...updateUser,
+      ...updatedUserInfo,
       interests: tags,
     };
   };
 
   const removeUserInfo = () => {
-    setUpdateUser(defaultValue);
+    setUpdatedUserInfo(defaultValue);
   };
 
   return (
-    <UpdateUserContext.Provider
+    <UserInfoContext.Provider
       value={{
-        updateUser,
-        setUpdateUser,
+        updatedUserInfo,
+        setUpdatedUserInfo,
         validateUserInfo,
-        setUserBasicInfo,
+        setBasicUserInfo,
         getUpdatedUserInfo,
         removeUserInfo,
       }}
     >
       {children}
-    </UpdateUserContext.Provider>
+    </UserInfoContext.Provider>
   );
 };
 
-export default UpdateUserProvider;
+export default UserInfoProvider;

--- a/web/components/Modal/User/contexts/UserInfoProvider.tsx
+++ b/web/components/Modal/User/contexts/UserInfoProvider.tsx
@@ -39,13 +39,9 @@ const UserInfoProvider = ({ children }: any) => {
     const imageLen = image.length;
 
     return {
-      name: !validateName(nameLen)
-        ? '1-8자 사이의 길이로 입력해주세요.'
-        : false,
-      introduce: !validateIntroduce(introduceLen)
-        ? '1-50자 사이의 길이로 입력해주세요.'
-        : false,
-      image: !validateImage(imageLen) ? '이미지를 업로드해주세요.' : false,
+      nameValue: validateName(nameLen),
+      introduceValue: validateIntroduce(introduceLen),
+      imageValue: validateImage(imageLen),
     };
   };
 

--- a/web/components/NavigationBar/LoginSection/LoginSection.tsx
+++ b/web/components/NavigationBar/LoginSection/LoginSection.tsx
@@ -37,12 +37,12 @@ const LoginSection = () => {
   return (
     <>
       <S.Line>|</S.Line>
-      <Avatar size={35} src={avatarSrc} />
-      <S.Line>|</S.Line>
       <S.UserContainer>
         {userInfoValue.user && (
           <Link href={`${PAGE_URL.USER}/${userInfoValue.user.id}`} passHref>
-            <S.NavItem>마이페이지</S.NavItem>
+            <S.AvatarWrapper>
+              <Avatar size={35} src={avatarSrc} />
+            </S.AvatarWrapper>
           </Link>
         )}
         <Button type="button" version="navBar" onClick={handleCreateFolder}>

--- a/web/components/NavigationBar/NavigationBar.style.ts
+++ b/web/components/NavigationBar/NavigationBar.style.ts
@@ -82,3 +82,14 @@ export const IconWrapper = styled.div`
     background-color: ${({ theme }) => theme.colors.gray[5]};
   }
 `;
+
+export const AvatarWrapper = styled.div`
+  width: fit-content;
+  height: fit-content;
+  border: ${({ theme }) => `1px solid ${theme.colors.gray[5]}`};
+  border-radius: 50%;
+
+  &:hover {
+    border: ${({ theme }) => `1px solid ${theme.colors.gray[3]}`};
+  }
+`;

--- a/web/constants/modal.constants.ts
+++ b/web/constants/modal.constants.ts
@@ -2,22 +2,33 @@ export const closeModal = {
   Login: false,
   SignUp: false,
   FirstLogin: false,
+  User: false,
 };
 
 export const showLoginModal = {
   Login: true,
   SignUp: false,
   FirstLogin: false,
+  User: false,
 };
 
 export const showSignUpModal = {
   Login: false,
   SignUp: true,
   FirstLogin: false,
+  User: false,
 };
 
 export const showFirstModal = {
   Login: false,
   SignUp: false,
   FirstLogin: true,
+  User: false,
+};
+
+export const showUserModal = {
+  Login: false,
+  SignUp: false,
+  FirstLogin: false,
+  User: true,
 };

--- a/web/pages/user/[id].tsx
+++ b/web/pages/user/[id].tsx
@@ -148,7 +148,7 @@ const UserPage = () => {
       }
     };
     fetch();
-  }, []);
+  }, [getUserInfo]);
 
   return (
     <>

--- a/web/pages/user/[id].tsx
+++ b/web/pages/user/[id].tsx
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { userInfo } from '../../recoil/user';
 import { Category, Modal, Pagination, Profile } from '../../components';
 import * as S from '../../styles/pageStyles/user.style';
@@ -17,16 +17,19 @@ import {
   getUserFolderList,
 } from '../../apis/FolderAPI';
 import { getCookie } from '../../util/cookies';
+import { showModalStatus } from '../../recoil/showModal';
+import { showUserModal } from '../../constants/modal.constants';
 
 const UserPage = () => {
   const router = useRouter();
   const id = parseInt(router.query.id.toString());
   const getUserInfo: any = useRecoilValue(userInfo);
   const loginUserId = getUserInfo?.user?.id;
+  const [showModal, setShowModal] = useRecoilState(showModalStatus);
 
   const [folderData, setFolderData] = useState([]);
   const [userData, setUserData] = useState<User>();
-  const [totalElement, setTotalElment] = useState(0);
+  const [totalElement, setTotalElement] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
 
   const [page, setPage] = useState(0);
@@ -46,14 +49,8 @@ const UserPage = () => {
         ];
   const [selectedItem, setSelectedItem] = useState(tabItems[0]);
 
-  const [showModal, setShowModal] = useState(false);
-
   const changeTabItem = (item: TabType) => {
     setSelectedItem(item);
-  };
-
-  const handleModal = () => {
-    setShowModal(!showModal);
   };
 
   useEffect(() => {
@@ -74,7 +71,7 @@ const UserPage = () => {
           });
           console.log(res);
           setFolderData(res.folders.content);
-          setTotalElment(res.folders.totalElements);
+          setTotalElement(res.folders.totalElements);
           setIsLoading(false);
         } catch {
           throw new Error('API 요청중 에러 발생');
@@ -94,7 +91,7 @@ const UserPage = () => {
             token,
           );
           setFolderData(res.folders.content);
-          setTotalElment(res.folders.totalElements);
+          setTotalElement(res.folders.totalElements);
           setIsLoading(false);
         } catch {
           throw new Error('API 요청중 에러 발생');
@@ -111,7 +108,7 @@ const UserPage = () => {
             id,
           );
           setFolderData(res.folders.content);
-          setTotalElment(res.folders.totalElements);
+          setTotalElement(res.folders.totalElements);
           setIsLoading(false);
         } catch {
           throw new Error('API 요청중 에러 발생');
@@ -122,7 +119,7 @@ const UserPage = () => {
           const res: PinnedFolder = await getPinnedFolder(token);
           console.log(res);
           setFolderData(res.folders);
-          setTotalElment(res.folders.length);
+          setTotalElement(res.folders.length);
           setIsLoading(false);
         } catch {
           throw new Error('API 요청중 에러 발생');
@@ -155,12 +152,15 @@ const UserPage = () => {
 
   return (
     <>
-      <Modal version="user" show={showModal} />
+      <Modal version="user" show={showModal.User} />
       <S.PageContainer>
         <S.ProfileWrapper>
           {userData && <Profile user={userData} />}
           {id === loginUserId && (
-            <S.ProfileModifyBtn type="button" onClick={handleModal}>
+            <S.ProfileModifyBtn
+              type="button"
+              onClick={() => setShowModal(showUserModal)}
+            >
               내 정보 수정
             </S.ProfileModifyBtn>
           )}

--- a/web/recoil/showModal.tsx
+++ b/web/recoil/showModal.tsx
@@ -6,5 +6,6 @@ export const showModalStatus = atom({
     Login: false,
     SignUp: false,
     FirstLogin: false,
+    User: false,
   },
 });

--- a/web/util/validateUserInfo.ts
+++ b/web/util/validateUserInfo.ts
@@ -1,0 +1,11 @@
+export const validateName = (len: number) => {
+  return len <= 8 && len > 0;
+};
+
+export const validateIntroduce = (len: number) => {
+  return len <= 50 && len > 0;
+};
+
+export const validateImage = (len: number) => {
+  return len > 0;
+};

--- a/web/util/validateUserInfo.ts
+++ b/web/util/validateUserInfo.ts
@@ -1,11 +1,22 @@
-export const validateName = (len: number) => {
-  return len <= 8 && len > 0;
+interface IsValidate {
+  status: boolean;
+  error: string;
+}
+
+export const validateName = (len: number): IsValidate => {
+  return len <= 8 && len > 0
+    ? { status: true, error: '' }
+    : { status: false, error: '1-8자 사이의 길이로 입력해주세요.' };
 };
 
 export const validateIntroduce = (len: number) => {
-  return len <= 50 && len > 0;
+  return len <= 50 && len > 0
+    ? { status: true, error: '' }
+    : { status: false, error: '1-50자 사이의 길이로 입력해주세요.' };
 };
 
 export const validateImage = (len: number) => {
-  return len > 0;
+  return len > 0
+    ? { status: true, error: '' }
+    : { status: false, error: '이미지를 업로드해주세요.' };
 };


### PR DESCRIPTION
# QA 이슈 해결 + 추가 구현

## 📌 설명
dev에서 발견한 모달 관련 + Navbar 문제 해결 및 추가 구현

<br />

## 🎨 구현 내용
### 1. Modal
- 사용 방법 페이지로 이동 후 모달 닫기
- 마지막 페이지 뒤로가는 버튼 없애기
- 엔터 클릭 시 다음 페이지로 이동 (input Component가 하나만 있는 경우 적용)

### 2. UserPage Modal
- User Page 회원 정보 수정 모달 구현
![image](https://user-images.githubusercontent.com/72294509/184503618-29db4314-619b-46e2-98ed-ac01513f28b0.png)
![image](https://user-images.githubusercontent.com/72294509/184503626-82ca769d-48bb-4cd7-a80a-3abb28369382.png)

- User Page 전역 유저 데이터 변경되면, 바로 반영되도록 수정
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/72294509/184503856-54039cd2-6a76-4129-b47d-12a4eeb092d1.gif)

### 3. Navbar
- Navbar 마이페이지 부분 수정
![image](https://user-images.githubusercontent.com/72294509/184503874-17b2a316-79a5-4cdf-b9ef-0ff1a8e5d575.png)

<br />

## ✅ 중점적으로 봐줬으면 하는 부분
- 추가 사항 있으시면 바로 반영하겠습니다.

## 🚀 연관된 이슈
Closes #125 
Closes #110 