### PR TITLE
Feat: TagSelector api 연동

### DIFF
--- a/web/components/Input/Input.tsx
+++ b/web/components/Input/Input.tsx
@@ -10,6 +10,8 @@ interface Props {
   onKeyDown?: KeyboardEventHandler;
   ref?: React.Ref<HTMLInputElement>;
   errorText?: string;
+  handleFoucsInput?: () => void;
+  handleBlurInput?: () => void;
 }
 
 const defaultProps = {
@@ -27,6 +29,8 @@ const Input = React.forwardRef<HTMLInputElement, Props>(
       type,
       onKeyDown,
       errorText,
+      handleFoucsInput,
+      handleBlurInput,
       ...styles
     },
     ref,
@@ -40,6 +44,8 @@ const Input = React.forwardRef<HTMLInputElement, Props>(
             maxLength={maxLength}
             onChange={onChange}
             onKeyDown={onKeyDown}
+            onFocus={handleFoucsInput}
+            onBlur={handleBlurInput}
             ref={ref}
             {...styles}
           />

--- a/web/components/Modal/Modal.style.ts
+++ b/web/components/Modal/Modal.style.ts
@@ -201,6 +201,16 @@ export const ConfirmButton = styled.button`
   border: none;
   border-radius: 30px;
   cursor: pointer;
+
+  &:hover {
+    transition: 0.25s;
+    box-shadow: 0 0.5em 0.5em -0.4em ${({ theme }) => theme.colors.gray[3]};
+    transform: translateY(-0.25em);
+  }
+  &:active {
+    transition: all 0.2s;
+    transform: scale(0.95);
+  }
 `;
 
 export const LogoText = styled.span`

--- a/web/components/Pagination/Pagination.tsx
+++ b/web/components/Pagination/Pagination.tsx
@@ -51,68 +51,79 @@ const Pagination = ({ defaultPage, limit, total, onChange }: Props) => {
   );
 
   return (
-    <S.PaginationContainer>
-      <ArrowButton isLeft onClick={() => page !== 0 && changePage(page - 1)} />
-      {filterdArray.map((i, index) => {
-        if (page < 4) {
-          if (totalPage > 5 && index === filterdArray.length - 2)
-            return (
-              <S.PaginationButton disable key={i}>
-                ...
-              </S.PaginationButton>
-            );
-          return (
-            <S.PaginationButton
-              onClick={() => changePage(i)}
-              disable={false}
-              key={i}
-              active={page === i}
-            >
-              {i + 1}
-            </S.PaginationButton>
-          );
-        }
-        if (page > totalPage - 5) {
-          if (index === 1)
-            return (
-              <S.PaginationButton disable key={i}>
-                ...
-              </S.PaginationButton>
-            );
-          return (
-            <S.PaginationButton
-              onClick={() => changePage(i)}
-              disable={false}
-              key={i}
-              active={page === i}
-            >
-              {i + 1}
-            </S.PaginationButton>
-          );
-        }
+    <>
+      {total !== 0 && (
+        <S.PaginationContainer>
+          <ArrowButton
+            isLeft
+            onClick={() => page !== 0 && changePage(page - 1)}
+          />
+          {filterdArray.map((i, index) => {
+            if (page < 4) {
+              if (totalPage > 5 && index === filterdArray.length - 2)
+                return (
+                  <S.PaginationButton disable key={i}>
+                    ...
+                  </S.PaginationButton>
+                );
+              return (
+                <S.PaginationButton
+                  onClick={() => changePage(i)}
+                  disable={false}
+                  key={i}
+                  active={page === i}
+                >
+                  {i + 1}
+                </S.PaginationButton>
+              );
+            }
+            if (page > totalPage - 5) {
+              if (index === 1)
+                return (
+                  <S.PaginationButton disable key={i}>
+                    ...
+                  </S.PaginationButton>
+                );
+              return (
+                <S.PaginationButton
+                  onClick={() => changePage(i)}
+                  disable={false}
+                  key={i}
+                  active={page === i}
+                >
+                  {i + 1}
+                </S.PaginationButton>
+              );
+            }
 
-        if (index === 1 || index === filterdArray.length - 2)
-          return (
-            <S.PaginationButton onClick={() => changePage(i)} disable key={i}>
-              ...
-            </S.PaginationButton>
-          );
-        return (
-          <S.PaginationButton
-            onClick={() => changePage(i)}
-            disable={false}
-            key={i}
-            active={page === i}
-          >
-            {i + 1}
-          </S.PaginationButton>
-        );
-      })}
-      <ArrowButton
-        isLeft={false}
-        onClick={() => page + 1 !== totalPage && changePage(page + 1)}
-      />
-    </S.PaginationContainer>
+            if (index === 1 || index === filterdArray.length - 2)
+              return (
+                <S.PaginationButton
+                  onClick={() => changePage(i)}
+                  disable
+                  key={i}
+                >
+                  ...
+                </S.PaginationButton>
+              );
+            return (
+              <S.PaginationButton
+                onClick={() => changePage(i)}
+                disable={false}
+                key={i}
+                active={page === i}
+              >
+                {i + 1}
+              </S.PaginationButton>
+            );
+          })}
+          <ArrowButton
+            isLeft={false}
+            onClick={() => page + 1 !== totalPage && changePage(page + 1)}
+          />
+        </S.PaginationContainer>
+      )}
+    </>
   );
 };
 

--- a/web/components/TagSelector/TagSelector.tsx
+++ b/web/components/TagSelector/TagSelector.tsx
@@ -17,13 +17,14 @@ const TagSelector = ({ selectedTag, setSelectedTag, ...styles }: Props) => {
   const listRef = useRef<HTMLUListElement>(null);
 
   const [activeItem, setActiveItem] = useState(0);
+  const [inputResultVisible, setInputResultVisible] = useState(false);
   const [autoCompleteSearch, setAutoCompleteSearch] = useState<string[]>(tags);
 
   useEffect(() => {
     (async () => {
       try {
         const res: TagType = await getTag();
-        let subTags: string[] = [];
+        const subTags: string[] = [];
 
         res.tags.forEach((tag: TagItemType) => {
           tag.subTags.forEach((subTag: string) => {
@@ -35,7 +36,7 @@ const TagSelector = ({ selectedTag, setSelectedTag, ...styles }: Props) => {
         setAutoCompleteSearch(subTags);
       } catch (error) {
         console.log(error);
-        alert('문제가 발생했습니다.')
+        alert('문제가 발생했습니다.');
       }
     })();
   }, []);
@@ -109,6 +110,14 @@ const TagSelector = ({ selectedTag, setSelectedTag, ...styles }: Props) => {
     }
   };
 
+  const handleFoucsInput = () => {
+    setInputResultVisible(true);
+  };
+
+  const handleBlurInput = () => {
+    setInputResultVisible(false);
+  };
+
   return (
     <S.Container {...styles}>
       <Tag tagItems={selectedTag} handleRemoveTag={handleRemoveTag} />
@@ -118,11 +127,13 @@ const TagSelector = ({ selectedTag, setSelectedTag, ...styles }: Props) => {
         placeholder="클릭 혹은 엔터를 사용해서 태그를 입력해 주세요."
         onChange={handleFilterInputValue}
         onKeyDown={handleKeyDown}
+        handleFoucsInput={handleFoucsInput}
+        handleBlurInput={handleBlurInput}
       />
       <InputResult
         active={activeItem}
         ref={listRef}
-        inputResultVisible={true}
+        inputResultVisible={inputResultVisible}
         inputResults={autoCompleteSearch}
         onClick={handleClickResultItem}
       />

--- a/web/components/TagSelector/TagSelector.tsx
+++ b/web/components/TagSelector/TagSelector.tsx
@@ -1,4 +1,8 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { getTag } from '../../apis/TagAPI';
+import { SubTagList } from '../../pageComponents/folderlistComponents/components/TagCategory/TagCategory.style';
+import { TagType } from '../../types';
+import { TagItemType } from '../../types/tag';
 import { Input, InputResult, Tag } from '../index';
 import * as S from './TagSelector.style';
 
@@ -8,28 +12,36 @@ interface Props {
 }
 
 const TagSelector = ({ selectedTag, setSelectedTag, ...styles }: Props) => {
-  // Todo: api요청 혹은 전역 데이터로 관리
-  const tags = [
-    '개발',
-    '쇼핑',
-    '코딩',
-    '취미',
-    '창업',
-    '마케팅',
-    '개발 필터링 테스트',
-    '쇼핑 필터링 테스트',
-    '코딩 필터링 테스트',
-    '취미 필터링 테스트',
-    '창업 필터링 테스트',
-    '마케팅 필터링 테스트',
-  ];
+  const [tags, setTags] = useState([]);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
 
   const [activeItem, setActiveItem] = useState(0);
   const [autoCompleteSearch, setAutoCompleteSearch] = useState<string[]>(tags);
 
+  useEffect(() => {
+    (async () => {
+      try {
+        const res: TagType = await getTag();
+        let subTags: string[] = [];
+
+        res.tags.forEach((tag: TagItemType) => {
+          tag.subTags.forEach((subTag: string) => {
+            subTags.push(subTag);
+          });
+        });
+
+        setTags(subTags);
+        setAutoCompleteSearch(subTags);
+      } catch (error) {
+        console.log(error);
+        alert('문제가 발생했습니다.')
+      }
+    })();
+  }, []);
+
   const handleFilterInputValue = () => {
+    console.log(tags);
     const keyword = inputRef.current.value;
     const filteredSearch = tags.filter((tag) => tag.indexOf(keyword) >= 0);
 
@@ -103,7 +115,7 @@ const TagSelector = ({ selectedTag, setSelectedTag, ...styles }: Props) => {
       <Input
         type="text"
         ref={inputRef}
-        placeholder="태그를 입력해 주세요! 클릭 혹은 엔터를 사용해서 입력할 수 있습니다."
+        placeholder="클릭 혹은 엔터를 사용해서 태그를 입력해 주세요."
         onChange={handleFilterInputValue}
         onKeyDown={handleKeyDown}
       />

--- a/web/types/tag.ts
+++ b/web/types/tag.ts
@@ -1,8 +1,8 @@
+export interface TagItemType {
+  rootTag: string;
+  subTags: string[];
+}
+
 export interface TagType {
-  tags: [
-    {
-      rootTag: string;
-      subTags: string[];
-    },
-  ];
+  tags: TagItemType[];
 }


### PR DESCRIPTION
# TagSelector Component getTag API 연동
![image](https://user-images.githubusercontent.com/72294509/184545298-7c36e438-4c2d-4cfc-b5ba-f0f950a78c51.png)

<br />

### 📌 설명
- API 연동으로 태그를 받아옵니다. 

<br />

### 🎨 구현 내용
- `TagSelector` Component API 연동
- `Pagenation` Component `total === 0` 일 경우 보이지 않게 예외처리

<br />

### ✅ 중점적으로 봐줬으면 하는 부분
TagSelector의 SubTags의 요소들만 골라 와 배열을 생성해야 합니다. 
해당 부분에 let을 사용했습니다.. 정말 사용하고 싶지 않았습니다. 
```
let subTags: string[] = [];

res.tags.forEach((tag: TagItemType) => {
  tag.subTags.forEach((subTag: string) => {
    subTags.push(subTag);
  });
});

setTags(subTags);
setAutoCompleteSearch(subTags);
```
이 부분을 어떻게 개선할 수 있을까요?

<br />

### 🚀 연관된 이슈
Closes #135 