### PR TITLE
Fix: Folder Update

### DIFF
--- a/web/pages/folderupdate/[id].tsx
+++ b/web/pages/folderupdate/[id].tsx
@@ -98,7 +98,7 @@ const FolderUpdate = () => {
         setImageSrc(image);
         contentInput.current.value = content;
         setBookmarks(bookmarks);
-        setOriginId(originFolder.id);
+        setOriginId(originFolder?.id);
       } catch (e) {
         router.push(`${PAGE_URL.ERROR}`);
         return;


### PR DESCRIPTION
### 📌 설명
<img width="719" alt="image" src="https://user-images.githubusercontent.com/59829606/196123811-92aeb8da-acd3-458d-8cf0-d27279f4229e.png">

catch문에 console을 찍어보니 다음과 같이 null값에서 id 속성을 읽으려고 하기 때문에 에러가 발생했고, 404 페이지로 리다이렉트 되었습니다.
따라서 optional chaining을 사용해 originFolder가 null값일 때는 에러를 발생시키지 않고 undefined를 반환하도록 수정하였습니다.
### 🎨 구현 내용
<!-- - 디렉토리, 파일 구조에 대한 설명
- 구현한 기능의 논리에 대한 설명
- 변경점에 대한 설명 -->

### ✅ 중점적으로 봐줬으면 하는 부분
<!-- - 변경사항이 큰 경우 집중해야 할 부분
- 불안해서 봐주었으면 하는 부분 등 -->

### 🚀 연관된 이슈
close #180 